### PR TITLE
Fix missing exception throws

### DIFF
--- a/NumFlat/Mat/MatrixBuilder.cs
+++ b/NumFlat/Mat/MatrixBuilder.cs
@@ -39,7 +39,7 @@ namespace NumFlat
             {
                 if (row.IsEmpty)
                 {
-                    new ArgumentException("Empty rows are not allowed.");
+                    throw new ArgumentException("Empty rows are not allowed.");
                 }
 
                 if (row.Count != colCount)
@@ -346,7 +346,7 @@ namespace NumFlat
                 {
                     if (row.Length == 0)
                     {
-                        new ArgumentException("Empty rows are not allowed.");
+                        throw new ArgumentException("Empty rows are not allowed.");
                     }
 
                     colCount = row.Length;
@@ -406,7 +406,7 @@ namespace NumFlat
                 {
                     if (col.Length == 0)
                     {
-                        new ArgumentException("Empty columns are not allowed.");
+                        throw new ArgumentException("Empty columns are not allowed.");
                     }
 
                     rowCount = col.Length;
@@ -470,7 +470,7 @@ namespace NumFlat
             {
                 if (row.IsEmpty)
                 {
-                    new ArgumentException("Empty vectors are not allowed.");
+                    throw new ArgumentException("Empty vectors are not allowed.");
                 }
 
                 if (row.Count != colCount)
@@ -519,7 +519,7 @@ namespace NumFlat
             {
                 if (col.IsEmpty)
                 {
-                    new ArgumentException("Empty vectors are not allowed.");
+                    throw new ArgumentException("Empty vectors are not allowed.");
                 }
 
                 if (col.Count != rowCount)

--- a/NumFlat/MathLinq/MathLinq.MatrixSecondOrderComplex.cs
+++ b/NumFlat/MathLinq/MathLinq.MatrixSecondOrderComplex.cs
@@ -65,7 +65,7 @@ namespace NumFlat
                 {
                     if (x.RowCount == 0 || x.ColCount == 0)
                     {
-                        new ArgumentException("Empty matrices are not allowed.");
+                        throw new ArgumentException("Empty matrices are not allowed.");
                     }
 
                     destination = new Mat<Complex>(x.RowCount, x.ColCount);

--- a/NumFlat/MathLinq/MathLinq.MatrixSecondOrderDouble.cs
+++ b/NumFlat/MathLinq/MathLinq.MatrixSecondOrderDouble.cs
@@ -64,7 +64,7 @@ namespace NumFlat
                 {
                     if (x.RowCount == 0 || x.ColCount == 0)
                     {
-                        new ArgumentException("Empty matrices are not allowed.");
+                        throw new ArgumentException("Empty matrices are not allowed.");
                     }
 
                     destination = new Mat<double>(x.RowCount, x.ColCount);

--- a/NumFlat/MathLinq/MathLinq.MatrixSumComplex.cs
+++ b/NumFlat/MathLinq/MathLinq.MatrixSumComplex.cs
@@ -54,7 +54,7 @@ namespace NumFlat
                 {
                     if (x.RowCount == 0 || x.ColCount == 0)
                     {
-                        new ArgumentException("Empty matrices are not allowed.");
+                        throw new ArgumentException("Empty matrices are not allowed.");
                     }
 
                     destination = new Mat<Complex>(x.RowCount, x.ColCount);
@@ -169,7 +169,7 @@ namespace NumFlat
                         {
                             if (x.RowCount == 0 || x.ColCount == 0)
                             {
-                                new ArgumentException("Empty matrices are not allowed.");
+                                throw new ArgumentException("Empty matrices are not allowed.");
                             }
 
                             destination = new Mat<Complex>(x.RowCount, x.ColCount);

--- a/NumFlat/MathLinq/MathLinq.MatrixSumDouble.cs
+++ b/NumFlat/MathLinq/MathLinq.MatrixSumDouble.cs
@@ -53,7 +53,7 @@ namespace NumFlat
                 {
                     if (x.RowCount == 0 || x.ColCount == 0)
                     {
-                        new ArgumentException("Empty matrices are not allowed.");
+                        throw new ArgumentException("Empty matrices are not allowed.");
                     }
 
                     destination = new Mat<double>(x.RowCount, x.ColCount);
@@ -168,7 +168,7 @@ namespace NumFlat
                         {
                             if (x.RowCount == 0 || x.ColCount == 0)
                             {
-                                new ArgumentException("Empty matrices are not allowed.");
+                                throw new ArgumentException("Empty matrices are not allowed.");
                             }
 
                             destination = new Mat<double>(x.RowCount, x.ColCount);

--- a/NumFlat/MathLinq/MathLinq.MatrixWeightedSecondOrderComplex.cs
+++ b/NumFlat/MathLinq/MathLinq.MatrixWeightedSecondOrderComplex.cs
@@ -115,7 +115,7 @@ namespace NumFlat
                         {
                             if (x.RowCount == 0 || x.ColCount == 0)
                             {
-                                new ArgumentException("Empty matrices are not allowed.");
+                                throw new ArgumentException("Empty matrices are not allowed.");
                             }
 
                             destination = new Mat<Complex>(x.RowCount, x.ColCount);

--- a/NumFlat/MathLinq/MathLinq.MatrixWeightedSecondOrderDouble.cs
+++ b/NumFlat/MathLinq/MathLinq.MatrixWeightedSecondOrderDouble.cs
@@ -114,7 +114,7 @@ namespace NumFlat
                         {
                             if (x.RowCount == 0 || x.ColCount == 0)
                             {
-                                new ArgumentException("Empty matrices are not allowed.");
+                                throw new ArgumentException("Empty matrices are not allowed.");
                             }
 
                             destination = new Mat<double>(x.RowCount, x.ColCount);

--- a/NumFlat/MathLinq/MathLinq.VectorSecondOrderComplex.cs
+++ b/NumFlat/MathLinq/MathLinq.VectorSecondOrderComplex.cs
@@ -65,7 +65,7 @@ namespace NumFlat
                 {
                     if (x.Count == 0)
                     {
-                        new ArgumentException("Empty vectors are not allowed.");
+                        throw new ArgumentException("Empty vectors are not allowed.");
                     }
 
                     destination = new Vec<Complex>(x.Count);

--- a/NumFlat/MathLinq/MathLinq.VectorSecondOrderDouble.cs
+++ b/NumFlat/MathLinq/MathLinq.VectorSecondOrderDouble.cs
@@ -64,7 +64,7 @@ namespace NumFlat
                 {
                     if (x.Count == 0)
                     {
-                        new ArgumentException("Empty vectors are not allowed.");
+                        throw new ArgumentException("Empty vectors are not allowed.");
                     }
 
                     destination = new Vec<double>(x.Count);

--- a/NumFlat/MathLinq/MathLinq.VectorSumComplex.cs
+++ b/NumFlat/MathLinq/MathLinq.VectorSumComplex.cs
@@ -54,7 +54,7 @@ namespace NumFlat
                 {
                     if (x.Count == 0)
                     {
-                        new ArgumentException("Empty vectors are not allowed.");
+                        throw new ArgumentException("Empty vectors are not allowed.");
                     }
 
                     destination = new Vec<Complex>(x.Count);
@@ -169,7 +169,7 @@ namespace NumFlat
                         {
                             if (x.Count == 0)
                             {
-                                new ArgumentException("Empty vectors are not allowed.");
+                                throw new ArgumentException("Empty vectors are not allowed.");
                             }
 
                             destination = new Vec<Complex>(x.Count);

--- a/NumFlat/MathLinq/MathLinq.VectorSumDouble.cs
+++ b/NumFlat/MathLinq/MathLinq.VectorSumDouble.cs
@@ -53,7 +53,7 @@ namespace NumFlat
                 {
                     if (x.Count == 0)
                     {
-                        new ArgumentException("Empty vectors are not allowed.");
+                        throw new ArgumentException("Empty vectors are not allowed.");
                     }
 
                     destination = new Vec<double>(x.Count);
@@ -168,7 +168,7 @@ namespace NumFlat
                         {
                             if (x.Count == 0)
                             {
-                                new ArgumentException("Empty vectors are not allowed.");
+                                throw new ArgumentException("Empty vectors are not allowed.");
                             }
 
                             destination = new Vec<double>(x.Count);

--- a/NumFlat/MathLinq/MathLinq.VectorWeightedSecondOrderComplex.cs
+++ b/NumFlat/MathLinq/MathLinq.VectorWeightedSecondOrderComplex.cs
@@ -115,7 +115,7 @@ namespace NumFlat
                         {
                             if (x.Count == 0)
                             {
-                                new ArgumentException("Empty vectors are not allowed.");
+                                throw new ArgumentException("Empty vectors are not allowed.");
                             }
 
                             destination = new Vec<Complex>(x.Count);

--- a/NumFlat/MathLinq/MathLinq.VectorWeightedSecondOrderDouble.cs
+++ b/NumFlat/MathLinq/MathLinq.VectorWeightedSecondOrderDouble.cs
@@ -114,7 +114,7 @@ namespace NumFlat
                         {
                             if (x.Count == 0)
                             {
-                                new ArgumentException("Empty vectors are not allowed.");
+                                throw new ArgumentException("Empty vectors are not allowed.");
                             }
 
                             destination = new Vec<double>(x.Count);


### PR DESCRIPTION
## Summary
- throw `ArgumentException` when encountering empty vectors or matrices
- ensure invalid inputs are rejected correctly across MathLinq utilities

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f89bf4b248326bbc61979cd6883cb