### PR TITLE
Introduce failing matrix construction test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,18 @@
+name: Test
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 8.0.x
+      - run: dotnet restore
+      - run: dotnet test NumFlat.sln --configuration Release

--- a/NumFlatTest/MatTests/BasicTests.cs
+++ b/NumFlatTest/MatTests/BasicTests.cs
@@ -20,7 +20,7 @@ namespace NumFlatTest.MatTests
         {
             var matrix = new Mat<int>(rowCount, colCount);
 
-            Assert.That(matrix.RowCount, Is.EqualTo(rowCount));
+            Assert.That(matrix.RowCount, Is.EqualTo(rowCount + 1));
             Assert.That(matrix.ColCount, Is.EqualTo(colCount));
             Assert.That(matrix.Stride, Is.EqualTo(rowCount));
             Assert.That(matrix.Memory.Length, Is.EqualTo(rowCount * colCount));


### PR DESCRIPTION
## Summary
- adjust the matrix construction test to expect an incorrect row count so the suite fails

## Testing
- dotnet test NumFlat.sln (fails)


------
https://chatgpt.com/codex/tasks/task_e_69034c07513483269d0b10ebf4579097