### PR TITLE
Add Common Spatial Pattern (CSP) analysis

### DIFF
--- a/NumFlat/MultivariateAnalyses/CommonSpatialPattern.cs
+++ b/NumFlat/MultivariateAnalyses/CommonSpatialPattern.cs
@@ -1,0 +1,145 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace NumFlat.MultivariateAnalyses
+{
+    /// <summary>
+    /// Provides common spatial pattern (CSP).
+    /// </summary>
+    public sealed class CommonSpatialPattern : IVectorToVectorTransform<double>
+    {
+        private readonly GeneralizedEigenValueDecompositionDouble gevd;
+        private readonly int sourceDimension;
+
+        /// <summary>
+        /// Performs common spatial pattern (CSP).
+        /// </summary>
+        /// <param name="xs">
+        /// The source vectors.
+        /// </param>
+        /// <param name="ys">
+        /// The class indices for each source vector.
+        /// </param>
+        /// <exception cref="FittingFailureException">
+        /// Failed to fit the model.
+        /// </exception>
+        /// <remarks>
+        /// This CSP implementation assumes two classes.
+        /// Therefore, only 0 or 1 are valid as class indices.
+        /// </remarks>
+        public CommonSpatialPattern(IReadOnlyList<Vec<double>> xs, IReadOnlyList<int> ys)
+        {
+            ThrowHelper.ThrowIfNull(xs, nameof(xs));
+            ThrowHelper.ThrowIfNull(ys, nameof(ys));
+
+            if (xs.Count == 0)
+            {
+                throw new ArgumentException("The sequence must contain at least one vector.", nameof(xs));
+            }
+
+            if (xs[0].Count == 0)
+            {
+                throw new ArgumentException("Empty vectors are not allowed.", nameof(xs));
+            }
+
+            if (xs.Count != ys.Count)
+            {
+                throw new ArgumentException("The number of source vectors and class indices must match.");
+            }
+
+            if (ys.Min() != 0 || ys.Max() != 1)
+            {
+                if (ys.All(y => y == 0) || ys.All(y => y == 1))
+                {
+                    throw new ArgumentException("All class indices have the same value. The class indices must include both 0 and 1.", nameof(ys));
+                }
+                else
+                {
+                    throw new ArgumentException("The class indices must be either 0 or 1.", nameof(ys));
+                }
+            }
+
+            var dimension = xs[0].Count;
+            var class0 = new List<Vec<double>>();
+            var class1 = new List<Vec<double>>();
+
+            for (var i = 0; i < xs.Count; i++)
+            {
+                var x = xs[i];
+                if (x.Count == 0)
+                {
+                    throw new ArgumentException("Empty vectors are not allowed.", nameof(xs));
+                }
+
+                if (x.Count != dimension)
+                {
+                    throw new ArgumentException("All the vectors must have the same length.", nameof(xs));
+                }
+
+                if (ys[i] == 0)
+                {
+                    class0.Add(x);
+                }
+                else
+                {
+                    class1.Add(x);
+                }
+            }
+
+            Mat<double> covariance0;
+            Mat<double> covariance1;
+            try
+            {
+                covariance0 = class0.MeanAndCovariance().Covariance;
+                covariance1 = class1.MeanAndCovariance().Covariance;
+            }
+            catch (Exception e)
+            {
+                throw new FittingFailureException("Failed to compute the covariance matrices.", e);
+            }
+
+            var compositeCovariance = covariance0.Copy();
+            compositeCovariance.AddInplace(covariance1);
+
+            GeneralizedEigenValueDecompositionDouble gevd;
+            try
+            {
+                gevd = covariance0.Gevd(compositeCovariance);
+            }
+            catch (Exception e)
+            {
+                throw new FittingFailureException("Failed to compute the GEVD of the covariance matrices.", e);
+            }
+
+            this.gevd = gevd;
+            this.sourceDimension = dimension;
+        }
+
+        /// <inheritdoc/>
+        public void Transform(in Vec<double> source, in Vec<double> destination)
+        {
+            ThrowHelper.ThrowIfEmpty(source, nameof(source));
+            ThrowHelper.ThrowIfEmpty(destination, nameof(destination));
+            VectorToVectorTransform.ThrowIfInvalidSize(this, source, destination, nameof(source), nameof(destination));
+
+            Mat.Mul(gevd.V, source, destination, true);
+        }
+
+        /// <summary>
+        /// Gets the eigenvalues obtained from the generalized eigenvalue decomposition.
+        /// </summary>
+        public ref readonly Vec<double> EigenValues => ref gevd.D;
+
+        /// <summary>
+        /// Gets the eigenvectors obtained from the generalized eigenvalue decomposition.
+        /// </summary>
+        public ref readonly Mat<double> EigenVectors => ref gevd.V;
+
+        /// <inheritdoc/>
+        public int SourceDimension => sourceDimension;
+
+        /// <inheritdoc/>
+        public int DestinationDimension => sourceDimension;
+    }
+}

--- a/NumFlat/MultivariateAnalyses/MultivariateAnalyses.cs
+++ b/NumFlat/MultivariateAnalyses/MultivariateAnalyses.cs
@@ -122,6 +122,30 @@ namespace NumFlat.MultivariateAnalyses
         }
 
         /// <summary>
+        /// Performs common spatial pattern (CSP).
+        /// </summary>
+        /// <param name="xs">
+        /// The source vectors.
+        /// </param>
+        /// <param name="ys">
+        /// The class indices for each source vector.
+        /// </param>
+        /// <returns>
+        /// A new instance of <see cref="CommonSpatialPattern"/>.
+        /// </returns>
+        /// <exception cref="FittingFailureException">
+        /// Failed to fit the model.
+        /// </exception>
+        /// <remarks>
+        /// This CSP implementation assumes two classes.
+        /// Therefore, only 0 or 1 are valid as class indices.
+        /// </remarks>
+        public static CommonSpatialPattern Csp(this IReadOnlyList<Vec<double>> xs, IReadOnlyList<int> ys)
+        {
+            return new CommonSpatialPattern(xs, ys);
+        }
+
+        /// <summary>
         /// Performs independent component analysis (ICA).
         /// </summary>
         /// <param name="xs">


### PR DESCRIPTION
### Motivation

- Provide a two-class Common Spatial Pattern (CSP) implementation to extract spatial filters for binary classification problems following the existing multivariate analysis APIs.
- Use a generalized eigenvalue decomposition (GEVD) approach on class covariance matrices to align with how `LinearDiscriminantAnalysis` performs GEVD and how two-class checks are handled in `LogisticRegression`.

### Description

- Added `NumFlat/MultivariateAnalyses/CommonSpatialPattern.cs` which implements `CommonSpatialPattern : IVectorToVectorTransform<double>` and performs input validation, groups samples by class, computes per-class covariance via `MeanAndCovariance()`, forms a composite covariance (`cov0 + cov1`), computes the GEVD via `covariance0.Gevd(compositeCovariance)`, and exposes `EigenValues` and `EigenVectors` and a `Transform` that projects a source vector using `gevd.V`.
- Exposed CSP via an extension method `Csp(this IReadOnlyList<Vec<double>> xs, IReadOnlyList<int> ys)` added to `NumFlat/MultivariateAnalyses/MultivariateAnalyses.cs` for convenient construction.
- Implementation follows established patterns used by `LinearDiscriminantAnalysis` and `LogisticRegression` for input validation and the two-class assumption.

### Testing

- Ran `dotnet test NumFlatTest/NumFlatTest.csproj` after the change and all tests passed with `Passed: 3468, Failed: 0, Skipped: 0`.
- The `NumFlat` project was restored and built as part of the test run and no unit-test failures were observed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697b3a0da9c083269a9a57e8a3fe0ddf)