### PR TITLE
Add XML doc comments for TimeSeries and IndexValuePair

### DIFF
--- a/NumFlat/IndexValuePair.cs
+++ b/NumFlat/IndexValuePair.cs
@@ -6,6 +6,9 @@ using System.Threading.Tasks;
 
 namespace NumFlat
 {
+    /// <summary>
+    /// Represents a pair of index and value.
+    /// </summary>
     public struct IndexValuePair<T>
     {
         private int index;
@@ -17,13 +20,22 @@ namespace NumFlat
             this.value = value;
         }
 
+        /// <summary>
+        /// <inheritdoc/>
+        /// </summary>
         public override string ToString()
         {
             return "(" + index + ", " + value + ")";
         }
 
+        /// <summary>
+        /// The index.
+        /// </summary>
         public int Index => index;
 
+        /// <summary>
+        /// The value.
+        /// </summary>
         public T Value => value;
     }
 }

--- a/NumFlat/TimeSeries/TimeSeries.cs
+++ b/NumFlat/TimeSeries/TimeSeries.cs
@@ -5,8 +5,16 @@ using System.Numerics;
 
 namespace NumFlat.TimeSeries
 {
+    /// <summary>
+    /// Provides utility methods for time-series data.
+    /// </summary>
     public static class TimeSeries
     {
+        /// <summary>
+        /// Finds local peaks in a vector.
+        /// </summary>
+        /// <param name="x">The input vector.</param>
+        /// <returns>An array of index-value pairs representing detected peaks.</returns>
         public static IndexValuePair<double>[] FindPeaks(in this Vec<double> x)
         {
             ThrowHelper.ThrowIfEmpty(x, nameof(x));


### PR DESCRIPTION
### Motivation
- Improve API discoverability and match existing codebase documentation style by adding XML documentation to time-series utilities and index/value pair types.

### Description
- Added XML doc comments to `NumFlat/TimeSeries/TimeSeries.cs` for the `TimeSeries` class and the `FindPeaks` extension method, and to `NumFlat/IndexValuePair.cs` for `IndexValuePair<T>`, its `ToString` override, and the `Index` and `Value` properties.

### Testing
- Ran `dotnet build -v minimal` at the repository root which failed due to no project/solution specified, and ran `dotnet build NumFlat/NumFlat.csproj -v minimal` which succeeded (build succeeded with 0 warnings/errors).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f18400f7e483268d6e711eacf83d04)