### PR TITLE
Add distance-constrained peak detection to TimeSeries

### DIFF
--- a/NumFlat/TimeSeries/TimeSeries.cs
+++ b/NumFlat/TimeSeries/TimeSeries.cs
@@ -61,5 +61,72 @@ namespace NumFlat.TimeSeries
 
             return peaks.ToArray();
         }
+
+        /// <summary>
+        /// Finds local peaks in a vector while enforcing a minimum distance between adjacent detected peaks.
+        /// </summary>
+        /// <param name="x">
+        /// The input vector.
+        /// </param>
+        /// <param name="distance">
+        /// Required minimal horizontal distance (in samples) between neighbouring peaks.
+        /// Must be greater than or equal to 1.
+        /// </param>
+        /// <returns>
+        /// An array of index-value pairs representing detected peaks.
+        /// </returns>
+        public static IndexValuePair<double>[] FindPeaksWithDistanceConstraint(in this Vec<double> x, int distance)
+        {
+            ThrowHelper.ThrowIfEmpty(x, nameof(x));
+
+            if (distance < 1)
+            {
+                throw new ArgumentOutOfRangeException(nameof(distance), "distance must be greater than or equal to 1.");
+            }
+
+            var peaks = x.FindPeaks();
+            if (peaks.Length <= 1 || distance == 1)
+            {
+                return peaks;
+            }
+
+            // Compatible with scipy.signal.find_peaks(distance=...):
+            // remove lower-priority peaks first, where priority is peak height.
+            var order = Enumerable.Range(0, peaks.Length)
+                .OrderByDescending(i => peaks[i].Value)
+                .ThenByDescending(i => peaks[i].Index)
+                .ToArray();
+
+            var keep = Enumerable.Repeat(true, peaks.Length).ToArray();
+            foreach (var i in order)
+            {
+                if (!keep[i])
+                {
+                    continue;
+                }
+
+                for (var j = i - 1; j >= 0; j--)
+                {
+                    if (peaks[i].Index - peaks[j].Index >= distance)
+                    {
+                        break;
+                    }
+
+                    keep[j] = false;
+                }
+
+                for (var j = i + 1; j < peaks.Length; j++)
+                {
+                    if (peaks[j].Index - peaks[i].Index >= distance)
+                    {
+                        break;
+                    }
+
+                    keep[j] = false;
+                }
+            }
+
+            return peaks.Where((peak, i) => keep[i]).ToArray();
+        }
     }
 }

--- a/NumFlatTest/TimeSeriesTests/FindPeaksTests.cs
+++ b/NumFlatTest/TimeSeriesTests/FindPeaksTests.cs
@@ -43,5 +43,46 @@ namespace NumFlatTest.TimeSeriesTests
                 Assert.That(a.Value, Is.EqualTo(b.Value));
             }
         }
+
+        [TestCase(1)]
+        [TestCase(2)]
+        [TestCase(3)]
+        [TestCase(5)]
+        [TestCase(10)]
+        public void DistanceConstraint(int distance)
+        {
+            var path = Path.Combine("dataset", "find_peaks_distance.csv");
+            var lines = File.ReadLines(path).ToArray();
+            var header = lines[0].Split(',');
+            var distanceColumn = Array.IndexOf(header, $"distance_{distance}");
+            Assert.That(distanceColumn, Is.GreaterThanOrEqualTo(0));
+
+            var referenceData = lines
+                .Skip(1)
+                .Select(line => line.Split(','))
+                .Select(value => (double.Parse(value[0]), int.Parse(value[distanceColumn])))
+                .ToArray();
+
+            var x = referenceData.Select(pair => pair.Item1).ToVector();
+
+            var expected = new List<(int Index, double Value)>();
+            for (var i = 0; i < x.Count; i++)
+            {
+                if (referenceData[i].Item2 == 1)
+                {
+                    expected.Add((i, x[i]));
+                }
+            }
+
+            var actual = x.FindPeaksWithDistanceConstraint(distance);
+
+            Assert.That(actual.Count, Is.EqualTo(expected.Count));
+
+            foreach (var (a, b) in actual.Zip(expected))
+            {
+                Assert.That(a.Index, Is.EqualTo(b.Index));
+                Assert.That(a.Value, Is.EqualTo(b.Value));
+            }
+        }
     }
 }


### PR DESCRIPTION
### Motivation
- Provide SciPy-compatible peak filtering by minimum horizontal distance so callers can request a minimum separation between detected peaks.
- Reuse the existing peak detection logic and avoid duplicating plateau/center handling by building on the current `FindPeaks` implementation.
- Ensure invalid `distance` values are rejected early to avoid surprising behavior.

### Description
- Added `TimeSeries.FindPeaksWithDistanceConstraint(in this Vec<double> x, int distance)` which calls `FindPeaks()` and applies a height-priority suppression to enforce the minimum `distance` between peaks, with ties broken by index order.
- The method validates `distance >= 1` and throws `ArgumentOutOfRangeException` for invalid values.
- Added parameterized unit tests `DistanceConstraint` in `NumFlatTest/TimeSeriesTests/FindPeaksTests.cs` that validate behavior for distances `1, 2, 3, 5, 10` against the SciPy-generated reference CSV `dataset/find_peaks_distance.csv`.

### Testing
- Ran the focused test suite with `dotnet test NumFlatTest/NumFlatTest.csproj --filter FindPeaksTests` and all tests passed.
- Test run summary: `Passed: 6, Failed: 0` for the `FindPeaksTests` filter.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f18b27c44c832685d4fb02343d9ea8)