### PR TITLE
Add FindPeaksWithProminenceConstraint and tests

### DIFF
--- a/NumFlat/TimeSeries/TimeSeries.cs
+++ b/NumFlat/TimeSeries/TimeSeries.cs
@@ -128,5 +128,80 @@ namespace NumFlat.TimeSeries
 
             return peaks.Where((peak, i) => keep[i]).ToArray();
         }
+
+        /// <summary>
+        /// Finds local peaks in a vector while enforcing a minimum prominence.
+        /// </summary>
+        /// <param name="x">
+        /// The input vector.
+        /// </param>
+        /// <param name="prominence">
+        /// Required minimum prominence. Must be greater than or equal to zero.
+        /// </param>
+        /// <returns>
+        /// An array of index-value pairs representing detected peaks.
+        /// </returns>
+        public static IndexValuePair<double>[] FindPeaksWithProminenceConstraint(in this Vec<double> x, double prominence)
+        {
+            ThrowHelper.ThrowIfEmpty(x, nameof(x));
+
+            if (prominence < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(prominence), "The prominence must be greater than or equal to zero.");
+            }
+
+            var peaks = x.FindPeaks();
+            if (peaks.Length == 0 || prominence == 0)
+            {
+                return peaks;
+            }
+
+            var fx = x.GetUnsafeFastIndexer();
+            var filtered = new List<IndexValuePair<double>>(peaks.Length);
+
+            foreach (var peak in peaks)
+            {
+                var peakIndex = peak.Index;
+                var peakValue = peak.Value;
+
+                var leftEdge = peakIndex;
+                while (leftEdge > 0 && fx[leftEdge - 1] <= peakValue)
+                {
+                    leftEdge--;
+                }
+
+                var rightEdge = peakIndex;
+                while (rightEdge < x.Count - 1 && fx[rightEdge + 1] <= peakValue)
+                {
+                    rightEdge++;
+                }
+
+                var leftBase = peakValue;
+                for (var i = leftEdge; i <= peakIndex; i++)
+                {
+                    if (fx[i] < leftBase)
+                    {
+                        leftBase = fx[i];
+                    }
+                }
+
+                var rightBase = peakValue;
+                for (var i = peakIndex; i <= rightEdge; i++)
+                {
+                    if (fx[i] < rightBase)
+                    {
+                        rightBase = fx[i];
+                    }
+                }
+
+                var actualProminence = peakValue - Math.Max(leftBase, rightBase);
+                if (actualProminence >= prominence)
+                {
+                    filtered.Add(peak);
+                }
+            }
+
+            return filtered.ToArray();
+        }
     }
 }

--- a/NumFlatTest/TimeSeriesTests/FindPeaksTests.cs
+++ b/NumFlatTest/TimeSeriesTests/FindPeaksTests.cs
@@ -83,5 +83,45 @@ namespace NumFlatTest.TimeSeriesTests
                 Assert.That(a.Value, Is.EqualTo(b.Value));
             }
         }
+
+        [TestCase(0.05)]
+        [TestCase(0.1)]
+        [TestCase(0.2)]
+        [TestCase(0.4)]
+        [TestCase(0.8)]
+        public void ProminenceConstraint(double prominence)
+        {
+            var path = Path.Combine("dataset", "find_peaks_prominence.csv");
+            var lines = File.ReadLines(path).ToArray();
+            var header = lines[0].Split(',');
+            var prominenceColumn = Array.IndexOf(header, $"prominence_{prominence}");
+
+            var referenceData = lines
+                .Skip(1)
+                .Select(line => line.Split(','))
+                .Select(value => (double.Parse(value[0]), int.Parse(value[prominenceColumn])))
+                .ToArray();
+
+            var x = referenceData.Select(pair => pair.Item1).ToVector();
+
+            var expected = new List<(int Index, double Value)>();
+            for (var i = 0; i < x.Count; i++)
+            {
+                if (referenceData[i].Item2 == 1)
+                {
+                    expected.Add((i, x[i]));
+                }
+            }
+
+            var actual = x.FindPeaksWithProminenceConstraint(prominence);
+
+            Assert.That(actual.Count, Is.EqualTo(expected.Count));
+
+            foreach (var (a, b) in actual.Zip(expected))
+            {
+                Assert.That(a.Index, Is.EqualTo(b.Index));
+                Assert.That(a.Value, Is.EqualTo(b.Value));
+            }
+        }
     }
 }


### PR DESCRIPTION
### Motivation
- Provide a convenience API to filter detected peaks by a minimum prominence threshold compatible with SciPy's `find_peaks(..., prominence=...)` behavior.
- Reuse existing peak-detection logic to avoid duplicating base peak finding and keep behavior consistent with other constraints.

### Description
- Added `TimeSeries.FindPeaksWithProminenceConstraint(in this Vec<double> x, double prominence)` which reuses `FindPeaks()` and filters peaks by computed prominence, returning peaks where `actualProminence >= prominence` and validating `prominence >= 0`.
- Prominence is computed by finding the left/right edges around the peak and their minimal base values, then subtracting the larger base from the peak value to get the prominence.
- Early-return behavior mirrors expectations: if there are no peaks or `prominence == 0` the original peaks are returned unchanged, and `prominence < 0` throws `ArgumentOutOfRangeException`.
- Updated tests in `FindPeaksTests` to add `ProminenceConstraint` parameterized test cases that read expected results from `NumFlatTest/dataset/find_peaks_prominence.csv`.

### Testing
- Ran `dotnet test NumFlatTest/NumFlatTest.csproj --filter FindPeaksTests` and all matched tests passed (Passed: 11, Failed: 0).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1904c9ad08326b21c99bbefa4cf70)