### PR TITLE
Upgrade MatFlat to 0.8.3 and adapt complex QR API

### DIFF
--- a/NumFlat/MatrixDecompositions/QrDecompositionComplex.cs
+++ b/NumFlat/MatrixDecompositions/QrDecompositionComplex.cs
@@ -82,11 +82,11 @@ namespace NumFlat
             using var utmp = TemporalMatrix.CopyFrom(a);
             ref readonly var tmp = ref utmp.Item;
 
-            using var urdiag = new TemporalArray<double>(a.ColCount);
+            using var urdiag = new TemporalArray<Complex>(a.ColCount);
             var rdiag = urdiag.Item;
 
             fixed (Complex* ptmp = tmp.Memory.Span)
-            fixed (double* prdiag = rdiag)
+            fixed (Complex* prdiag = rdiag)
             fixed (Complex* pq = q.Memory.Span)
             fixed (Complex* pr = r.Memory.Span)
             {

--- a/NumFlat/NumFlat.csproj
+++ b/NumFlat/NumFlat.csproj
@@ -29,7 +29,7 @@
 
   <ItemGroup>
     <PackageReference Include="FftFlat" Version="1.0.1" />
-    <PackageReference Include="MatFlat" Version="0.8.2" />
+    <PackageReference Include="MatFlat" Version="0.8.3" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
### Motivation
- Bring the MatFlat dependency up to `0.8.3` to pick up recent fixes and API changes.
- Fix QR decomposition call sites that broke due to the MatFlat `Factorization` API change for complex-valued `rdiag` handling.

### Description
- Updated the package reference in `NumFlat/NumFlat.csproj` from `MatFlat` `0.8.2` to `0.8.3`.
- Adapted `QrDecompositionComplex` to allocate `rdiag` as `TemporalArray<Complex>` and pass a `Complex*` (`prdiag`) to the MatFlat QR functions to match the 0.8.3 signatures.

### Testing
- Ran `dotnet build NumFlatTest/NumFlatTest.csproj` and the build succeeded for the test project.
- Ran `dotnet test NumFlatTest/NumFlatTest.csproj` and all tests passed (`Passed: 3520, Failed: 0, Skipped: 0`).
- Attempting `dotnet build NumFlat.slnx` fails on this SDK because the `.slnx` `<Solution>` element is not supported, so tests were executed by building and running the test project directly.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01762db72083268d6ee7b8689ce85e)