### PR TITLE
Add System.Text.Json converters and options for NumFlat Vec/Mat with tests and packaging metadata

### DIFF
--- a/SerializationJson/Class1.cs
+++ b/SerializationJson/Class1.cs
@@ -1,7 +1,0 @@
-﻿namespace NumFlatSerializationJson
-{
-    public class Class1
-    {
-
-    }
-}

--- a/SerializationJson/MatJsonConverter.cs
+++ b/SerializationJson/MatJsonConverter.cs
@@ -1,0 +1,88 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Numerics;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace NumFlat.Serialization.Json
+{
+    internal sealed class MatJsonConverter<T> : JsonConverter<Mat<T>> where T : unmanaged, INumberBase<T>
+    {
+        public override Mat<T> Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            if (reader.TokenType != JsonTokenType.StartArray)
+            {
+                throw new JsonException("A NumFlat matrix must be represented as a JSON array of row arrays.");
+            }
+
+            var rows = new List<Vec<T>>();
+
+            while (reader.Read())
+            {
+                if (reader.TokenType == JsonTokenType.EndArray)
+                {
+                    return CreateMatrix(rows);
+                }
+
+                if (reader.TokenType != JsonTokenType.StartArray)
+                {
+                    throw new JsonException("Each NumFlat matrix row must be represented as a JSON array.");
+                }
+
+                var row = ReadRow(ref reader, options);
+                rows.Add(row);
+            }
+
+            throw new JsonException("The JSON array for a NumFlat matrix is incomplete.");
+        }
+
+        public override void Write(Utf8JsonWriter writer, Mat<T> value, JsonSerializerOptions options)
+        {
+            writer.WriteStartArray();
+            for (var row = 0; row < value.RowCount; row++)
+            {
+                writer.WriteStartArray();
+                for (var col = 0; col < value.ColCount; col++)
+                {
+                    JsonSerializer.Serialize(writer, value[row, col], options);
+                }
+                writer.WriteEndArray();
+            }
+            writer.WriteEndArray();
+        }
+
+        private static Vec<T> ReadRow(ref Utf8JsonReader reader, JsonSerializerOptions options)
+        {
+            var elements = new List<T>();
+            while (reader.Read())
+            {
+                if (reader.TokenType == JsonTokenType.EndArray)
+                {
+                    if (elements.Count == 0)
+                    {
+                        throw new JsonException("A NumFlat matrix row cannot be empty.");
+                    }
+
+                    return new Vec<T>(elements.ToArray());
+                }
+
+                var element = JsonSerializer.Deserialize<T>(ref reader, options);
+                elements.Add(element);
+            }
+
+            throw new JsonException("The JSON array for a NumFlat matrix row is incomplete.");
+        }
+
+        private static Mat<T> CreateMatrix(List<Vec<T>> rows)
+        {
+            try
+            {
+                return MatrixBuilder.Create<T>(rows.ToArray());
+            }
+            catch (ArgumentException ex)
+            {
+                throw new JsonException("The JSON array cannot be converted to a NumFlat matrix.", ex);
+            }
+        }
+    }
+}

--- a/SerializationJson/MatJsonConverterFactory.cs
+++ b/SerializationJson/MatJsonConverterFactory.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace NumFlat.Serialization.Json
+{
+    /// <summary>
+    /// Creates JSON converters for <see cref="Mat{T}" />.
+    /// </summary>
+    public sealed class MatJsonConverterFactory : JsonConverterFactory
+    {
+        /// <inheritdoc />
+        public override bool CanConvert(Type typeToConvert)
+        {
+            if (!typeToConvert.IsGenericType)
+            {
+                return false;
+            }
+
+            return typeToConvert.GetGenericTypeDefinition() == typeof(Mat<>);
+        }
+
+        /// <inheritdoc />
+        public override JsonConverter CreateConverter(Type typeToConvert, JsonSerializerOptions options)
+        {
+            var elementType = typeToConvert.GetGenericArguments()[0];
+            var converterType = typeof(MatJsonConverter<>).MakeGenericType(elementType);
+            return (JsonConverter)Activator.CreateInstance(converterType)!;
+        }
+    }
+}

--- a/SerializationJson/NumFlatJsonSerializerOptions.cs
+++ b/SerializationJson/NumFlatJsonSerializerOptions.cs
@@ -1,0 +1,35 @@
+﻿using System.Text.Json;
+
+namespace NumFlat.Serialization.Json
+{
+    /// <summary>
+    /// Provides factory methods for <see cref="JsonSerializerOptions" /> configured for NumFlat types.
+    /// </summary>
+    public static class NumFlatJsonSerializerOptions
+    {
+        /// <summary>
+        /// Creates serializer options that include converters for <see cref="Vec{T}" /> and <see cref="Mat{T}" />.
+        /// </summary>
+        /// <returns>
+        /// A new <see cref="JsonSerializerOptions" /> instance configured for NumFlat types.
+        /// </returns>
+        public static JsonSerializerOptions Create()
+        {
+            return new JsonSerializerOptions().AddNumFlatConverters();
+        }
+
+        /// <summary>
+        /// Creates serializer options by copying existing options and adding converters for <see cref="Vec{T}" /> and <see cref="Mat{T}" />.
+        /// </summary>
+        /// <param name="options">
+        /// The source options to copy.
+        /// </param>
+        /// <returns>
+        /// A new <see cref="JsonSerializerOptions" /> instance configured for NumFlat types.
+        /// </returns>
+        public static JsonSerializerOptions Create(JsonSerializerOptions options)
+        {
+            return new JsonSerializerOptions(options).AddNumFlatConverters();
+        }
+    }
+}

--- a/SerializationJson/NumFlatJsonSerializerOptionsExtensions.cs
+++ b/SerializationJson/NumFlatJsonSerializerOptionsExtensions.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace NumFlat.Serialization.Json
+{
+    /// <summary>
+    /// Provides extension methods for configuring <see cref="JsonSerializerOptions" /> to handle NumFlat types.
+    /// </summary>
+    public static class NumFlatJsonSerializerOptionsExtensions
+    {
+        /// <summary>
+        /// Adds converters for <see cref="Vec{T}" /> and <see cref="Mat{T}" /> to the specified options.
+        /// </summary>
+        /// <param name="options">
+        /// The serializer options to configure.
+        /// </param>
+        /// <returns>
+        /// The same <see cref="JsonSerializerOptions" /> instance so calls can be chained.
+        /// </returns>
+        public static JsonSerializerOptions AddNumFlatConverters(this JsonSerializerOptions options)
+        {
+            if (options == null)
+            {
+                throw new ArgumentNullException(nameof(options));
+            }
+
+            AddConverterIfMissing<VecJsonConverterFactory>(options);
+            AddConverterIfMissing<MatJsonConverterFactory>(options);
+            return options;
+        }
+
+        private static void AddConverterIfMissing<TConverter>(JsonSerializerOptions options)
+            where TConverter : JsonConverter, new()
+        {
+            foreach (var converter in options.Converters)
+            {
+                if (converter.GetType() == typeof(TConverter))
+                {
+                    return;
+                }
+            }
+
+            options.Converters.Add(new TConverter());
+        }
+    }
+}

--- a/SerializationJson/SerializationJson.csproj
+++ b/SerializationJson/SerializationJson.csproj
@@ -4,6 +4,25 @@
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>disable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>True</GenerateDocumentationFile>
+    <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
+    <Title>NumFlat.Serialization.Json</Title>
+    <PackageId>NumFlat.Serialization.Json</PackageId>
+    <AssemblyName>NumFlat.Serialization.Json</AssemblyName>
+    <RootNamespace>NumFlat.Serialization.Json</RootNamespace>
+    <Version>1.2.4</Version>
+    <Authors>Nobuaki Tanaka</Authors>
+    <Description>System.Text.Json converters for NumFlat vectors and matrices.</Description>
+    <PackageProjectUrl>https://github.com/sinshu/numflat</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/sinshu/numflat</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <PackageTags>math;numerics;linear;algebra;matrix;vector;json;serialization</PackageTags>
+    <PackageReleaseNotes>https://github.com/sinshu/numflat/blob/main/CHANGELOG.md</PackageReleaseNotes>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
   </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\NumFlat\NumFlat.csproj" />
+  </ItemGroup>
 
 </Project>

--- a/SerializationJson/VecJsonConverter.cs
+++ b/SerializationJson/VecJsonConverter.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Numerics;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace NumFlat.Serialization.Json
+{
+    internal sealed class VecJsonConverter<T> : JsonConverter<Vec<T>> where T : unmanaged, INumberBase<T>
+    {
+        public override Vec<T> Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            if (reader.TokenType != JsonTokenType.StartArray)
+            {
+                throw new JsonException("A NumFlat vector must be represented as a JSON array.");
+            }
+
+            var elements = new List<T>();
+            while (reader.Read())
+            {
+                if (reader.TokenType == JsonTokenType.EndArray)
+                {
+                    if (elements.Count == 0)
+                    {
+                        throw new JsonException("A NumFlat vector cannot be empty.");
+                    }
+
+                    return new Vec<T>(elements.ToArray());
+                }
+
+                var element = JsonSerializer.Deserialize<T>(ref reader, options);
+                elements.Add(element);
+            }
+
+            throw new JsonException("The JSON array for a NumFlat vector is incomplete.");
+        }
+
+        public override void Write(Utf8JsonWriter writer, Vec<T> value, JsonSerializerOptions options)
+        {
+            writer.WriteStartArray();
+            foreach (var element in value)
+            {
+                JsonSerializer.Serialize(writer, element, options);
+            }
+            writer.WriteEndArray();
+        }
+    }
+}

--- a/SerializationJson/VecJsonConverterFactory.cs
+++ b/SerializationJson/VecJsonConverterFactory.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace NumFlat.Serialization.Json
+{
+    /// <summary>
+    /// Creates JSON converters for <see cref="Vec{T}" />.
+    /// </summary>
+    public sealed class VecJsonConverterFactory : JsonConverterFactory
+    {
+        /// <inheritdoc />
+        public override bool CanConvert(Type typeToConvert)
+        {
+            if (!typeToConvert.IsGenericType)
+            {
+                return false;
+            }
+
+            return typeToConvert.GetGenericTypeDefinition() == typeof(Vec<>);
+        }
+
+        /// <inheritdoc />
+        public override JsonConverter CreateConverter(Type typeToConvert, JsonSerializerOptions options)
+        {
+            var elementType = typeToConvert.GetGenericArguments()[0];
+            var converterType = typeof(VecJsonConverter<>).MakeGenericType(elementType);
+            return (JsonConverter)Activator.CreateInstance(converterType)!;
+        }
+    }
+}

--- a/SerializationJsonTest/SerializationJsonTest.csproj
+++ b/SerializationJsonTest/SerializationJsonTest.csproj
@@ -18,6 +18,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\SerializationJson\SerializationJson.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
     <Using Include="NUnit.Framework" />
   </ItemGroup>
 

--- a/SerializationJsonTest/UnitTest1.cs
+++ b/SerializationJsonTest/UnitTest1.cs
@@ -1,16 +1,94 @@
+using System.Linq;
+using System.Text.Json;
+using NumFlat;
+using NumFlat.Serialization.Json;
+
 namespace SerializationJsonTest
 {
     public class Tests
     {
-        [SetUp]
-        public void Setup()
+        [Test]
+        public void DeserializeVector()
         {
+            var options = NumFlatJsonSerializerOptions.Create();
+
+            var vector = JsonSerializer.Deserialize<Vec<int>>("[1,2,3]", options);
+
+            Assert.That(vector.Count, Is.EqualTo(3));
+            Assert.That(vector.Stride, Is.EqualTo(1));
+            Assert.That(vector.ToArray(), Is.EqualTo(new[] { 1, 2, 3 }));
         }
 
         [Test]
-        public void Test1()
+        public void DeserializeMatrix()
         {
-            Assert.Pass();
+            var options = NumFlatJsonSerializerOptions.Create();
+
+            var matrix = JsonSerializer.Deserialize<Mat<double>>("[[1,2,3],[4,5,6]]", options);
+
+            Assert.That(matrix.RowCount, Is.EqualTo(2));
+            Assert.That(matrix.ColCount, Is.EqualTo(3));
+            Assert.That(matrix.Stride, Is.EqualTo(2));
+            Assert.That(matrix[0, 0], Is.EqualTo(1));
+            Assert.That(matrix[0, 1], Is.EqualTo(2));
+            Assert.That(matrix[0, 2], Is.EqualTo(3));
+            Assert.That(matrix[1, 0], Is.EqualTo(4));
+            Assert.That(matrix[1, 1], Is.EqualTo(5));
+            Assert.That(matrix[1, 2], Is.EqualTo(6));
+        }
+
+        [Test]
+        public void RoundTripVectorKeepsArrayShape()
+        {
+            var options = new JsonSerializerOptions().AddNumFlatConverters();
+            var source = new Vec<int>(3, 2, new[] { 1, -1, 2, -1, 3 });
+
+            var json = JsonSerializer.Serialize(source, options);
+            var actual = JsonSerializer.Deserialize<Vec<int>>(json, options);
+
+            Assert.That(json, Is.EqualTo("[1,2,3]"));
+            Assert.That(actual.ToArray(), Is.EqualTo(new[] { 1, 2, 3 }));
+        }
+
+        [Test]
+        public void RoundTripMatrixKeepsArrayOfRowsShape()
+        {
+            var options = new JsonSerializerOptions().AddNumFlatConverters();
+            var source = new Mat<int>(2, 3, 4, new[] { 1, 4, -1, -1, 2, 5, -1, -1, 3, 6 });
+
+            var json = JsonSerializer.Serialize(source, options);
+            var actual = JsonSerializer.Deserialize<Mat<int>>(json, options);
+
+            Assert.That(json, Is.EqualTo("[[1,2,3],[4,5,6]]"));
+            Assert.That(actual.RowCount, Is.EqualTo(2));
+            Assert.That(actual.ColCount, Is.EqualTo(3));
+            Assert.That(actual[0, 0], Is.EqualTo(1));
+            Assert.That(actual[0, 1], Is.EqualTo(2));
+            Assert.That(actual[0, 2], Is.EqualTo(3));
+            Assert.That(actual[1, 0], Is.EqualTo(4));
+            Assert.That(actual[1, 1], Is.EqualTo(5));
+            Assert.That(actual[1, 2], Is.EqualTo(6));
+        }
+
+        [Test]
+        public void DeserializeInvalidMatrixThrowsJsonException()
+        {
+            var options = NumFlatJsonSerializerOptions.Create();
+
+            Assert.That(() => JsonSerializer.Deserialize<Mat<int>>("[]", options), Throws.TypeOf<JsonException>());
+            Assert.That(() => JsonSerializer.Deserialize<Mat<int>>("[[]]", options), Throws.TypeOf<JsonException>());
+            Assert.That(() => JsonSerializer.Deserialize<Mat<int>>("[[1,2],[3]]", options), Throws.TypeOf<JsonException>());
+        }
+
+        [Test]
+        public void AddNumFlatConvertersDoesNotAddDuplicates()
+        {
+            var options = new JsonSerializerOptions();
+
+            options.AddNumFlatConverters().AddNumFlatConverters();
+
+            Assert.That(options.Converters.OfType<VecJsonConverterFactory>().Count(), Is.EqualTo(1));
+            Assert.That(options.Converters.OfType<MatJsonConverterFactory>().Count(), Is.EqualTo(1));
         }
     }
 }


### PR DESCRIPTION
### Motivation
- Provide JSON (de)serialization support for NumFlat `Vec<T>` and `Mat<T>` so vectors and matrices can be serialized as JSON arrays.
- Expose a convenient way to configure `JsonSerializerOptions` for NumFlat types and avoid duplicate converter registration.
- Prepare the serialization package with proper project metadata and integrate it into the solution for testing and packaging.

### Description
- Implemented `VecJsonConverter<T>` and `MatJsonConverter<T>` to serialize/deserialize vectors as JSON arrays and matrices as arrays of row arrays, with validation and clear `JsonException` messages.
- Added converter factories `VecJsonConverterFactory` and `MatJsonConverterFactory` and extension method `AddNumFlatConverters` plus helper `NumFlatJsonSerializerOptions` to create configured `JsonSerializerOptions`. 
- Added unit tests (`SerializationJsonTest/UnitTest1.cs`) covering deserialization, round-trip serialization, invalid input handling, and duplicate-converter prevention. 
- Updated `SerializationJson.csproj` with package metadata, build/package settings and a project reference to the core `NumFlat` project, and removed the placeholder `Class1.cs`.

### Testing
- Ran `dotnet build` and `dotnet test` for the `SerializationJsonTest` project to exercise the new converters. 
- All unit tests passed, verifying vector/matrix deserialization, round-trip serialization preserves shape and contents, invalid matrix inputs throw `JsonException`, and `AddNumFlatConverters` does not add duplicate converters.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a066873623c8326a20928c4f7e39a36)