### PR TITLE
Allow empty Vec/Mat JSON round-trips and fix NUnit ambiguity

### DIFF
--- a/SerializationJson/MatJsonConverter.cs
+++ b/SerializationJson/MatJsonConverter.cs
@@ -75,6 +75,11 @@ namespace NumFlat.Serialization.Json
 
         private static Mat<T> CreateMatrix(List<Vec<T>> rows)
         {
+            if (rows.Count == 0)
+            {
+                return default;
+            }
+
             try
             {
                 return MatrixBuilder.Create<T>(rows.ToArray());

--- a/SerializationJson/VecJsonConverter.cs
+++ b/SerializationJson/VecJsonConverter.cs
@@ -22,7 +22,7 @@ namespace NumFlat.Serialization.Json
                 {
                     if (elements.Count == 0)
                     {
-                        throw new JsonException("A NumFlat vector cannot be empty.");
+                        return default;
                     }
 
                     return new Vec<T>(elements.ToArray());

--- a/SerializationJsonTest/VectorMatrixTests.cs
+++ b/SerializationJsonTest/VectorMatrixTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Linq;
 using System.Text.Json;
 using NumFlat;
@@ -20,6 +21,17 @@ namespace SerializationJsonTest
         }
 
         [Test]
+        public void DeserializeEmptyVector()
+        {
+            var options = NumFlatJsonSerializerOptions.Create();
+
+            var vector = JsonSerializer.Deserialize<Vec<int>>("[]", options);
+
+            Assert.That(vector.IsEmpty, Is.True);
+            Assert.That(vector.Count, Is.EqualTo(0));
+        }
+
+        [Test]
         public void DeserializeMatrix()
         {
             var options = NumFlatJsonSerializerOptions.Create();
@@ -38,6 +50,18 @@ namespace SerializationJsonTest
         }
 
         [Test]
+        public void DeserializeEmptyMatrix()
+        {
+            var options = NumFlatJsonSerializerOptions.Create();
+
+            var matrix = JsonSerializer.Deserialize<Mat<double>>("[]", options);
+
+            Assert.That(matrix.IsEmpty, Is.True);
+            Assert.That(matrix.RowCount, Is.EqualTo(0));
+            Assert.That(matrix.ColCount, Is.EqualTo(0));
+        }
+
+        [Test]
         public void RoundTripVectorKeepsArrayShape()
         {
             var options = new JsonSerializerOptions().AddNumFlatConverters();
@@ -48,6 +72,20 @@ namespace SerializationJsonTest
 
             Assert.That(json, Is.EqualTo("[1,2,3]"));
             Assert.That(actual.ToArray(), Is.EqualTo(new[] { 1, 2, 3 }));
+        }
+
+        [Test]
+        public void RoundTripEmptyVectorKeepsArrayShape()
+        {
+            var options = new JsonSerializerOptions().AddNumFlatConverters();
+            var source = default(Vec<int>);
+
+            var json = JsonSerializer.Serialize(source, options);
+            var actual = JsonSerializer.Deserialize<Vec<int>>(json, options);
+
+            Assert.That(json, Is.EqualTo("[]"));
+            Assert.That(actual.IsEmpty, Is.True);
+            Assert.That(actual.Count, Is.EqualTo(0));
         }
 
         [Test]
@@ -71,13 +109,27 @@ namespace SerializationJsonTest
         }
 
         [Test]
+        public void RoundTripEmptyMatrixKeepsArrayOfRowsShape()
+        {
+            var options = new JsonSerializerOptions().AddNumFlatConverters();
+            var source = default(Mat<int>);
+
+            var json = JsonSerializer.Serialize(source, options);
+            var actual = JsonSerializer.Deserialize<Mat<int>>(json, options);
+
+            Assert.That(json, Is.EqualTo("[]"));
+            Assert.That(actual.IsEmpty, Is.True);
+            Assert.That(actual.RowCount, Is.EqualTo(0));
+            Assert.That(actual.ColCount, Is.EqualTo(0));
+        }
+
+        [Test]
         public void DeserializeInvalidMatrixThrowsJsonException()
         {
             var options = NumFlatJsonSerializerOptions.Create();
 
-            Assert.That(() => JsonSerializer.Deserialize<Mat<int>>("[]", options), Throws.TypeOf<JsonException>());
-            Assert.That(() => JsonSerializer.Deserialize<Mat<int>>("[[]]", options), Throws.TypeOf<JsonException>());
-            Assert.That(() => JsonSerializer.Deserialize<Mat<int>>("[[1,2],[3]]", options), Throws.TypeOf<JsonException>());
+            Assert.That((Action)(() => JsonSerializer.Deserialize<Mat<int>>("[[]]", options)), Throws.TypeOf<JsonException>());
+            Assert.That((Action)(() => JsonSerializer.Deserialize<Mat<int>>("[[1,2],[3]]", options)), Throws.TypeOf<JsonException>());
         }
 
         [Test]


### PR DESCRIPTION
### Motivation
- JSON (de)serialization should accept empty vectors/matrices so `Vec<T>`/`Mat<T>` can round-trip an empty JSON array `[]` instead of failing. 
- Updating NUnit introduced an overload ambiguity for `Assert.That(() => ...)` which broke tests and needs to be addressed.

### Description
- Changed `SerializationJson/VecJsonConverter.cs` so deserializing `[]` returns `default(Vec<T>)` instead of throwing. 
- Changed `SerializationJson/MatJsonConverter.cs` so a top-level `[]` returns `default(Mat<T>)` while keeping empty rows like `[[]]` invalid. 
- Added tests in `SerializationJsonTest/VectorMatrixTests.cs`: `DeserializeEmptyVector`, `DeserializeEmptyMatrix`, `RoundTripEmptyVectorKeepsArrayShape`, and `RoundTripEmptyMatrixKeepsArrayOfRowsShape`. 
- Updated exception assertions to cast lambdas to `(Action)` and added `using System;` in the test file to resolve NUnit overload ambiguity after the package update.

### Testing
- Ran `dotnet test SerializationJsonTest/SerializationJsonTest.csproj` and all tests passed (`Passed: 10`).
- Ran `dotnet test NumFlatTest/NumFlatTest.csproj` and all tests passed (`Passed: 3520`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a06703323c8832682d79cd3d27be8a4)