### PR TITLE
Add PCA parameterized constructor and JSON (de)serializer; register converter

### DIFF
--- a/NumFlat/MultivariateAnalyses/PrincipalComponentAnalysis.cs
+++ b/NumFlat/MultivariateAnalyses/PrincipalComponentAnalysis.cs
@@ -9,7 +9,8 @@ namespace NumFlat.MultivariateAnalyses
     public sealed class PrincipalComponentAnalysis : IVectorToVectorInverseTransform<double>
     {
         private readonly Vec<double> mean;
-        private readonly EigenValueDecompositionDouble evd;
+        private readonly Vec<double> eigenValues;
+        private readonly Mat<double> eigenVectors;
 
         /// <summary>
         /// Performs principal component analysis (PCA).
@@ -46,7 +47,45 @@ namespace NumFlat.MultivariateAnalyses
             }
 
             this.mean = mean;
-            this.evd = evd;
+            this.eigenValues = evd.D;
+            this.eigenVectors = evd.V;
+        }
+
+        /// <summary>
+        /// Creates principal component analysis (PCA) from fitted parameters.
+        /// </summary>
+        /// <param name="mean">
+        /// The mean vector of the source vectors.
+        /// </param>
+        /// <param name="eigenValues">
+        /// The eigenvalues of the covariance matrix.
+        /// </param>
+        /// <param name="eigenVectors">
+        /// The eigenvectors of the covariance matrix.
+        /// </param>
+        /// <remarks>
+        /// This constructor is intended primarily for deserializers that reconstruct a fitted model from persisted parameters.
+        /// The given vectors and matrix are stored directly, so they should not be mutated after construction.
+        /// </remarks>
+        public PrincipalComponentAnalysis(in Vec<double> mean, in Vec<double> eigenValues, in Mat<double> eigenVectors)
+        {
+            ThrowHelper.ThrowIfEmpty(mean, nameof(mean));
+            ThrowHelper.ThrowIfEmpty(eigenValues, nameof(eigenValues));
+            ThrowHelper.ThrowIfEmpty(eigenVectors, nameof(eigenVectors));
+
+            if (eigenValues.Count != mean.Count)
+            {
+                throw new ArgumentException($"The length of the eigenvalue vector must be {mean.Count}, but was {eigenValues.Count}.", nameof(eigenValues));
+            }
+
+            if (eigenVectors.RowCount != mean.Count || eigenVectors.ColCount != mean.Count)
+            {
+                throw new ArgumentException($"The eigenvector matrix must be {mean.Count} x {mean.Count}, but was {eigenVectors.RowCount} x {eigenVectors.ColCount}.", nameof(eigenVectors));
+            }
+
+            this.mean = mean;
+            this.eigenValues = eigenValues;
+            this.eigenVectors = eigenVectors;
         }
 
         /// <inheritdoc/>
@@ -69,7 +108,7 @@ namespace NumFlat.MultivariateAnalyses
             ref readonly var tmp = ref utmp.Item;
 
             Vec.Sub(source, mean, tmp);
-            Mat.Mul(evd.V.Submatrix(0, 0, mean.Count, destination.Count), tmp, destination, true);
+            Mat.Mul(eigenVectors.Submatrix(0, 0, mean.Count, destination.Count), tmp, destination, true);
         }
 
         /// <inheritdoc/>
@@ -88,7 +127,7 @@ namespace NumFlat.MultivariateAnalyses
                 throw new ArgumentException($"The transform requires the length of the destination vector to be {mean.Count}, but was {destination.Count}.", nameof(destination));
             }
 
-            Mat.Mul(evd.V.Submatrix(0, 0, mean.Count, source.Count), source, destination, false);
+            Mat.Mul(eigenVectors.Submatrix(0, 0, mean.Count, source.Count), source, destination, false);
             destination.AddInplace(mean);
         }
 
@@ -100,12 +139,12 @@ namespace NumFlat.MultivariateAnalyses
         /// <summary>
         /// Gets the eigenvalues of the covariance matrix.
         /// </summary>
-        public ref readonly Vec<double> EigenValues => ref evd.D;
+        public ref readonly Vec<double> EigenValues => ref eigenValues;
 
         /// <summary>
         /// Gets the eigenvectors of the covariance matrix.
         /// </summary>
-        public ref readonly Mat<double> EigenVectors => ref evd.V;
+        public ref readonly Mat<double> EigenVectors => ref eigenVectors;
 
         /// <inheritdoc/>
         public int SourceDimension => mean.Count;

--- a/NumFlatTest/MultivariateAnalysesTests/PcaTests.cs
+++ b/NumFlatTest/MultivariateAnalysesTests/PcaTests.cs
@@ -59,6 +59,28 @@ namespace NumFlatTest.MultivariateAnalysesTests
             }
         }
 
+        [Test]
+        public void ConstructorFromParametersStoresInputsDirectly()
+        {
+            var mean = new Vec<double>(new[] { 1.0, 2.0 });
+            var eigenValues = new Vec<double>(new[] { 3.0, 4.0 });
+            var eigenVectors = new Mat<double>(2, 2, 2, new[]
+            {
+                1.0, 0.0,
+                0.0, 1.0
+            });
+
+            var pca = new PrincipalComponentAnalysis(mean, eigenValues, eigenVectors);
+
+            mean[0] = 10.0;
+            eigenValues[0] = 30.0;
+            eigenVectors[0, 0] = 100.0;
+
+            Assert.That(pca.Mean[0], Is.EqualTo(10.0));
+            Assert.That(pca.EigenValues[0], Is.EqualTo(30.0));
+            Assert.That(pca.EigenVectors[0, 0], Is.EqualTo(100.0));
+        }
+
         private static IEnumerable<Vec<double>> ReadIris(string filename)
         {
             var path = Path.Combine("dataset", filename);

--- a/SerializationJson/NumFlatJsonSerializerOptions.cs
+++ b/SerializationJson/NumFlatJsonSerializerOptions.cs
@@ -8,7 +8,7 @@ namespace NumFlat.Serialization.Json
     public static class NumFlatJsonSerializerOptions
     {
         /// <summary>
-        /// Creates serializer options that include converters for <see cref="Vec{T}" /> and <see cref="Mat{T}" />.
+        /// Creates serializer options that include converters for NumFlat types.
         /// </summary>
         /// <returns>
         /// A new <see cref="JsonSerializerOptions" /> instance configured for NumFlat types.
@@ -19,7 +19,7 @@ namespace NumFlat.Serialization.Json
         }
 
         /// <summary>
-        /// Creates serializer options by copying existing options and adding converters for <see cref="Vec{T}" /> and <see cref="Mat{T}" />.
+        /// Creates serializer options by copying existing options and adding converters for NumFlat types.
         /// </summary>
         /// <param name="options">
         /// The source options to copy.

--- a/SerializationJson/NumFlatJsonSerializerOptionsExtensions.cs
+++ b/SerializationJson/NumFlatJsonSerializerOptionsExtensions.cs
@@ -10,7 +10,7 @@ namespace NumFlat.Serialization.Json
     public static class NumFlatJsonSerializerOptionsExtensions
     {
         /// <summary>
-        /// Adds converters for <see cref="Vec{T}" /> and <see cref="Mat{T}" /> to the specified options.
+        /// Adds converters for NumFlat types to the specified options.
         /// </summary>
         /// <param name="options">
         /// The serializer options to configure.
@@ -27,6 +27,7 @@ namespace NumFlat.Serialization.Json
 
             AddConverterIfMissing<VecJsonConverterFactory>(options);
             AddConverterIfMissing<MatJsonConverterFactory>(options);
+            AddConverterIfMissing<PrincipalComponentAnalysisJsonConverter>(options);
             return options;
         }
 

--- a/SerializationJson/PrincipalComponentAnalysisJsonConverter.cs
+++ b/SerializationJson/PrincipalComponentAnalysisJsonConverter.cs
@@ -1,0 +1,109 @@
+﻿using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using NumFlat.MultivariateAnalyses;
+
+namespace NumFlat.Serialization.Json
+{
+    /// <summary>
+    /// Converts <see cref="PrincipalComponentAnalysis" /> instances to and from JSON.
+    /// </summary>
+    public sealed class PrincipalComponentAnalysisJsonConverter : JsonConverter<PrincipalComponentAnalysis>
+    {
+        private const string MeanPropertyName = "mean";
+        private const string EigenValuesPropertyName = "eigenValues";
+        private const string EigenVectorsPropertyName = "eigenVectors";
+
+        /// <inheritdoc />
+        public override PrincipalComponentAnalysis Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            if (reader.TokenType != JsonTokenType.StartObject)
+            {
+                throw new JsonException("A NumFlat PCA object must be represented as a JSON object.");
+            }
+
+            Vec<double>? mean = null;
+            Vec<double>? eigenValues = null;
+            Mat<double>? eigenVectors = null;
+
+            while (reader.Read())
+            {
+                if (reader.TokenType == JsonTokenType.EndObject)
+                {
+                    if (mean == null)
+                    {
+                        throw new JsonException("The JSON object for a NumFlat PCA object must contain a 'mean' property.");
+                    }
+
+                    if (eigenValues == null)
+                    {
+                        throw new JsonException("The JSON object for a NumFlat PCA object must contain an 'eigenValues' property.");
+                    }
+
+                    if (eigenVectors == null)
+                    {
+                        throw new JsonException("The JSON object for a NumFlat PCA object must contain an 'eigenVectors' property.");
+                    }
+
+                    try
+                    {
+                        return new PrincipalComponentAnalysis(mean.Value, eigenValues.Value, eigenVectors.Value);
+                    }
+                    catch (ArgumentException ex)
+                    {
+                        throw new JsonException("The JSON object cannot be converted to a NumFlat PCA object.", ex);
+                    }
+                }
+
+                if (reader.TokenType != JsonTokenType.PropertyName)
+                {
+                    throw new JsonException("A NumFlat PCA object property name is expected.");
+                }
+
+                var propertyName = reader.GetString();
+                if (!reader.Read())
+                {
+                    throw new JsonException("The JSON object for a NumFlat PCA object is incomplete.");
+                }
+
+                if (StringEquals(propertyName, MeanPropertyName, options))
+                {
+                    mean = JsonSerializer.Deserialize<Vec<double>>(ref reader, options);
+                }
+                else if (StringEquals(propertyName, EigenValuesPropertyName, options))
+                {
+                    eigenValues = JsonSerializer.Deserialize<Vec<double>>(ref reader, options);
+                }
+                else if (StringEquals(propertyName, EigenVectorsPropertyName, options))
+                {
+                    eigenVectors = JsonSerializer.Deserialize<Mat<double>>(ref reader, options);
+                }
+                else
+                {
+                    reader.Skip();
+                }
+            }
+
+            throw new JsonException("The JSON object for a NumFlat PCA object is incomplete.");
+        }
+
+        /// <inheritdoc />
+        public override void Write(Utf8JsonWriter writer, PrincipalComponentAnalysis value, JsonSerializerOptions options)
+        {
+            writer.WriteStartObject();
+            writer.WritePropertyName(MeanPropertyName);
+            JsonSerializer.Serialize(writer, value.Mean, options);
+            writer.WritePropertyName(EigenValuesPropertyName);
+            JsonSerializer.Serialize(writer, value.EigenValues, options);
+            writer.WritePropertyName(EigenVectorsPropertyName);
+            JsonSerializer.Serialize(writer, value.EigenVectors, options);
+            writer.WriteEndObject();
+        }
+
+        private static bool StringEquals(string? value, string expected, JsonSerializerOptions options)
+        {
+            var comparison = options.PropertyNameCaseInsensitive ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
+            return string.Equals(value, expected, comparison);
+        }
+    }
+}

--- a/SerializationJson/SerializationJson.csproj
+++ b/SerializationJson/SerializationJson.csproj
@@ -12,7 +12,7 @@
     <RootNamespace>NumFlat.Serialization.Json</RootNamespace>
     <Version>1.2.4</Version>
     <Authors>Nobuaki Tanaka</Authors>
-    <Description>System.Text.Json converters for NumFlat vectors and matrices.</Description>
+    <Description>System.Text.Json converters for NumFlat types.</Description>
     <PackageProjectUrl>https://github.com/sinshu/numflat</PackageProjectUrl>
     <RepositoryUrl>https://github.com/sinshu/numflat</RepositoryUrl>
     <RepositoryType>git</RepositoryType>

--- a/SerializationJsonTest/PrincipalComponentAnalysisTests.cs
+++ b/SerializationJsonTest/PrincipalComponentAnalysisTests.cs
@@ -1,0 +1,79 @@
+using System;
+using System.Linq;
+using System.Text.Json;
+using NumFlat;
+using NumFlat.MultivariateAnalyses;
+using NumFlat.Serialization.Json;
+
+namespace SerializationJsonTest
+{
+    public class PrincipalComponentAnalysisTests
+    {
+        [Test]
+        public void RoundTripPcaKeepsFittedParameters()
+        {
+            var options = NumFlatJsonSerializerOptions.Create();
+            var source = CreatePca();
+
+            var json = JsonSerializer.Serialize(source, options);
+            var actual = JsonSerializer.Deserialize<PrincipalComponentAnalysis>(json, options)!;
+
+            Assert.That(json, Is.EqualTo("{\"mean\":[1,2],\"eigenValues\":[3,4],\"eigenVectors\":[[0,1],[1,0]]}"));
+            Assert.That(actual.Mean.ToArray(), Is.EqualTo(new[] { 1.0, 2.0 }));
+            Assert.That(actual.EigenValues.ToArray(), Is.EqualTo(new[] { 3.0, 4.0 }));
+            Assert.That(actual.EigenVectors[0, 0], Is.EqualTo(0.0));
+            Assert.That(actual.EigenVectors[0, 1], Is.EqualTo(1.0));
+            Assert.That(actual.EigenVectors[1, 0], Is.EqualTo(1.0));
+            Assert.That(actual.EigenVectors[1, 1], Is.EqualTo(0.0));
+        }
+
+        [Test]
+        public void RoundTripPcaKeepsTransformBehavior()
+        {
+            var options = NumFlatJsonSerializerOptions.Create();
+            var source = CreatePca();
+            var x = new Vec<double>(new[] { 5.0, 7.0 });
+            var expected = source.Transform(x);
+
+            var json = JsonSerializer.Serialize(source, options);
+            var actual = JsonSerializer.Deserialize<PrincipalComponentAnalysis>(json, options)!;
+            var actualTransformed = actual.Transform(x);
+            var restored = actual.InverseTransform(actualTransformed);
+
+            Assert.That(actualTransformed.ToArray(), Is.EqualTo(expected.ToArray()).Within(1.0e-12));
+            Assert.That(restored.ToArray(), Is.EqualTo(x.ToArray()).Within(1.0e-12));
+        }
+
+        [Test]
+        public void DeserializePcaWithInvalidShapeThrowsJsonException()
+        {
+            var options = NumFlatJsonSerializerOptions.Create();
+            const string json = "{\"mean\":[1,2],\"eigenValues\":[3],\"eigenVectors\":[[1,0],[0,1]]}";
+
+            Assert.That((Action)(() => JsonSerializer.Deserialize<PrincipalComponentAnalysis>(json, options)), Throws.TypeOf<JsonException>());
+        }
+
+        [Test]
+        public void AddNumFlatConvertersAddsPcaConverterOnce()
+        {
+            var options = new JsonSerializerOptions();
+
+            options.AddNumFlatConverters().AddNumFlatConverters();
+
+            Assert.That(options.Converters.OfType<PrincipalComponentAnalysisJsonConverter>().Count(), Is.EqualTo(1));
+        }
+
+        private static PrincipalComponentAnalysis CreatePca()
+        {
+            var mean = new Vec<double>(new[] { 1.0, 2.0 });
+            var eigenValues = new Vec<double>(new[] { 3.0, 4.0 });
+            var eigenVectors = new Mat<double>(2, 2, 2, new[]
+            {
+                0.0, 1.0,
+                1.0, 0.0
+            });
+
+            return new PrincipalComponentAnalysis(mean, eigenValues, eigenVectors);
+        }
+    }
+}

--- a/SerializationJsonTest/VectorMatrixTests.cs
+++ b/SerializationJsonTest/VectorMatrixTests.cs
@@ -141,6 +141,7 @@ namespace SerializationJsonTest
 
             Assert.That(options.Converters.OfType<VecJsonConverterFactory>().Count(), Is.EqualTo(1));
             Assert.That(options.Converters.OfType<MatJsonConverterFactory>().Count(), Is.EqualTo(1));
+            Assert.That(options.Converters.OfType<PrincipalComponentAnalysisJsonConverter>().Count(), Is.EqualTo(1));
         }
     }
 }


### PR DESCRIPTION
### Motivation

- Allow `PrincipalComponentAnalysis` instances to be reconstructed from persisted parameters and be JSON serializable. 
- Decouple storage from the internal `EigenValueDecompositionDouble` type so fitted parameters can be stored and inspected directly. 
- Integrate PCA converter into the library `JsonSerializerOptions` so NumFlat types are serialized consistently.

### Description

- Replaced the single `EigenValueDecompositionDouble evd` field in `PrincipalComponentAnalysis` with `Vec<double> eigenValues` and `Mat<double> eigenVectors`, and updated `Transform`/`InverseTransform` and property accessors to use the new fields. 
- Added a parameterized constructor `PrincipalComponentAnalysis(in Vec<double> mean, in Vec<double> eigenValues, in Mat<double> eigenVectors)` with input validation and a doc remark for deserialization use. 
- Implemented `PrincipalComponentAnalysisJsonConverter` to serialize/deserialize PCA objects using the properties `mean`, `eigenValues`, and `eigenVectors`. 
- Registered the new converter in `NumFlatJsonSerializerOptions.AddNumFlatConverters()` and added tests to ensure converters are not duplicated. 
- Added unit tests in `SerializationJsonTest/PrincipalComponentAnalysisTests.cs` covering round-trip serialization, transform behavior preservation, invalid-shape errors, and `AddNumFlatConverters` behavior, and added a PCA unit test `ConstructorFromParametersStoresInputsDirectly` in `PcaTests.cs`. 
- Updated project metadata description in `SerializationJson.csproj` to reference NumFlat types more broadly.

### Testing

- Ran `NumFlatTest.MultivariateAnalysesTests.PcaTests` (including the new `ConstructorFromParametersStoresInputsDirectly`), and the tests passed. 
- Ran `SerializationJsonTest.PrincipalComponentAnalysisTests` (round-trip, behavior, and error cases), and the tests passed. 
- Ran `SerializationJsonTest.VectorMatrixTests` (including duplicate-converter checks), and the tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a06828e71a483269deede9f65324e84)