### PR TITLE
Add JSON serialization for LDA

### DIFF
--- a/NumFlat/MultivariateAnalyses/LinearDiscriminantAnalysis.cs
+++ b/NumFlat/MultivariateAnalyses/LinearDiscriminantAnalysis.cs
@@ -10,7 +10,8 @@ namespace NumFlat.MultivariateAnalyses
     public sealed class LinearDiscriminantAnalysis : IVectorToVectorTransform<double>
     {
         private readonly Vec<double> mean;
-        private readonly GeneralizedEigenValueDecompositionDouble gevd;
+        private readonly Vec<double> eigenValues;
+        private readonly Mat<double> eigenVectors;
 
         /// <summary>
         /// Performs linear discriminant analysis (LDA).
@@ -55,7 +56,45 @@ namespace NumFlat.MultivariateAnalyses
             }
 
             this.mean = xs.Mean();
-            this.gevd = gevd;
+            this.eigenValues = gevd.D;
+            this.eigenVectors = gevd.V;
+        }
+
+        /// <summary>
+        /// Creates linear discriminant analysis (LDA) from fitted parameters.
+        /// </summary>
+        /// <param name="mean">
+        /// The mean vector of the source vectors.
+        /// </param>
+        /// <param name="eigenValues">
+        /// The eigenvalues obtained from the generalized eigenvalue decomposition.
+        /// </param>
+        /// <param name="eigenVectors">
+        /// The eigenvectors obtained from the generalized eigenvalue decomposition.
+        /// </param>
+        /// <remarks>
+        /// This constructor is intended primarily for deserializers that reconstruct a fitted model from persisted parameters.
+        /// The given vectors and matrix are stored directly, so they should not be mutated after construction.
+        /// </remarks>
+        public LinearDiscriminantAnalysis(in Vec<double> mean, in Vec<double> eigenValues, in Mat<double> eigenVectors)
+        {
+            ThrowHelper.ThrowIfEmpty(mean, nameof(mean));
+            ThrowHelper.ThrowIfEmpty(eigenValues, nameof(eigenValues));
+            ThrowHelper.ThrowIfEmpty(eigenVectors, nameof(eigenVectors));
+
+            if (eigenValues.Count != mean.Count)
+            {
+                throw new ArgumentException($"The length of the eigenvalue vector must be {mean.Count}, but was {eigenValues.Count}.", nameof(eigenValues));
+            }
+
+            if (eigenVectors.RowCount != mean.Count || eigenVectors.ColCount != mean.Count)
+            {
+                throw new ArgumentException($"The eigenvector matrix must be {mean.Count} x {mean.Count}, but was {eigenVectors.RowCount} x {eigenVectors.ColCount}.", nameof(eigenVectors));
+            }
+
+            this.mean = mean;
+            this.eigenValues = eigenValues;
+            this.eigenVectors = eigenVectors;
         }
 
         /// <inheritdoc/>
@@ -69,7 +108,7 @@ namespace NumFlat.MultivariateAnalyses
             ref readonly var tmp = ref utmp.Item;
 
             Vec.Sub(source, mean, tmp);
-            Mat.Mul(gevd.V, tmp, destination, true);
+            Mat.Mul(eigenVectors, tmp, destination, true);
         }
 
         /// <summary>
@@ -80,12 +119,12 @@ namespace NumFlat.MultivariateAnalyses
         /// <summary>
         /// Gets the eigenvalues obtained from the generalized eigenvalue decomposition.
         /// </summary>
-        public ref readonly Vec<double> EigenValues => ref gevd.D;
+        public ref readonly Vec<double> EigenValues => ref eigenValues;
 
         /// <summary>
         /// Gets the eigenvectors obtained from the generalized eigenvalue decomposition.
         /// </summary>
-        public ref readonly Mat<double> EigenVectors => ref gevd.V;
+        public ref readonly Mat<double> EigenVectors => ref eigenVectors;
 
         /// <inheritdoc/>
         public int SourceDimension => mean.Count;

--- a/SerializationJson/EigenTransformJsonConverterCore.cs
+++ b/SerializationJson/EigenTransformJsonConverterCore.cs
@@ -1,0 +1,116 @@
+﻿using System;
+using System.Text.Json;
+
+namespace NumFlat.Serialization.Json
+{
+    internal static class EigenTransformJsonConverterCore
+    {
+        private const string MeanPropertyName = "mean";
+        private const string EigenValuesPropertyName = "eigenValues";
+        private const string EigenVectorsPropertyName = "eigenVectors";
+
+        public static TTransform Read<TTransform>(
+            ref Utf8JsonReader reader,
+            JsonSerializerOptions options,
+            string modelName,
+            Func<Vec<double>, Vec<double>, Mat<double>, TTransform> createTransform)
+        {
+            if (reader.TokenType != JsonTokenType.StartObject)
+            {
+                throw new JsonException($"A NumFlat {modelName} object must be represented as a JSON object.");
+            }
+
+            Vec<double>? mean = null;
+            Vec<double>? eigenValues = null;
+            Mat<double>? eigenVectors = null;
+
+            while (reader.Read())
+            {
+                if (reader.TokenType == JsonTokenType.EndObject)
+                {
+                    return CreateTransform(mean, eigenValues, eigenVectors, modelName, createTransform);
+                }
+
+                if (reader.TokenType != JsonTokenType.PropertyName)
+                {
+                    throw new JsonException($"A NumFlat {modelName} object property name is expected.");
+                }
+
+                var propertyName = reader.GetString();
+                if (!reader.Read())
+                {
+                    throw new JsonException($"The JSON object for a NumFlat {modelName} object is incomplete.");
+                }
+
+                if (JsonSerializationHelpers.PropertyNameEquals(propertyName, MeanPropertyName, options))
+                {
+                    mean = JsonSerializer.Deserialize<Vec<double>>(ref reader, options);
+                }
+                else if (JsonSerializationHelpers.PropertyNameEquals(propertyName, EigenValuesPropertyName, options))
+                {
+                    eigenValues = JsonSerializer.Deserialize<Vec<double>>(ref reader, options);
+                }
+                else if (JsonSerializationHelpers.PropertyNameEquals(propertyName, EigenVectorsPropertyName, options))
+                {
+                    eigenVectors = JsonSerializer.Deserialize<Mat<double>>(ref reader, options);
+                }
+                else
+                {
+                    reader.Skip();
+                }
+            }
+
+            throw new JsonException($"The JSON object for a NumFlat {modelName} object is incomplete.");
+        }
+
+        public static void Write<TTransform>(
+            Utf8JsonWriter writer,
+            TTransform value,
+            JsonSerializerOptions options,
+            Func<TTransform, Vec<double>> getMean,
+            Func<TTransform, Vec<double>> getEigenValues,
+            Func<TTransform, Mat<double>> getEigenVectors)
+        {
+            writer.WriteStartObject();
+            writer.WritePropertyName(MeanPropertyName);
+            JsonSerializer.Serialize(writer, getMean(value), options);
+            writer.WritePropertyName(EigenValuesPropertyName);
+            JsonSerializer.Serialize(writer, getEigenValues(value), options);
+            writer.WritePropertyName(EigenVectorsPropertyName);
+            JsonSerializer.Serialize(writer, getEigenVectors(value), options);
+            writer.WriteEndObject();
+        }
+
+        private static TTransform CreateTransform<TTransform>(
+            Vec<double>? mean,
+            Vec<double>? eigenValues,
+            Mat<double>? eigenVectors,
+            string modelName,
+            Func<Vec<double>, Vec<double>, Mat<double>, TTransform> createTransform)
+        {
+            if (mean == null)
+            {
+                throw new JsonException($"The JSON object for a NumFlat {modelName} object must contain a 'mean' property.");
+            }
+
+            if (eigenValues == null)
+            {
+                throw new JsonException($"The JSON object for a NumFlat {modelName} object must contain an 'eigenValues' property.");
+            }
+
+            if (eigenVectors == null)
+            {
+                throw new JsonException($"The JSON object for a NumFlat {modelName} object must contain an 'eigenVectors' property.");
+            }
+
+            try
+            {
+                return createTransform(mean.Value, eigenValues.Value, eigenVectors.Value);
+            }
+            catch (ArgumentException ex)
+            {
+                throw new JsonException($"The JSON object cannot be converted to a NumFlat {modelName} object.", ex);
+            }
+        }
+    }
+}

--- a/SerializationJson/JsonSerializationHelpers.cs
+++ b/SerializationJson/JsonSerializationHelpers.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace NumFlat.Serialization.Json
+{
+    internal static class JsonSerializationHelpers
+    {
+        public static bool PropertyNameEquals(string? value, string expected, JsonSerializerOptions options)
+        {
+            var comparison = options.PropertyNameCaseInsensitive ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
+            return string.Equals(value, expected, comparison);
+        }
+
+        public static void AddConverterIfMissing<TConverter>(JsonSerializerOptions options)
+            where TConverter : JsonConverter, new()
+        {
+            foreach (var converter in options.Converters)
+            {
+                if (converter.GetType() == typeof(TConverter))
+                {
+                    return;
+                }
+            }
+
+            options.Converters.Add(new TConverter());
+        }
+
+        public static JsonConverter CreateGenericConverter(Type genericConverterTypeDefinition, Type elementType)
+        {
+            var converterType = genericConverterTypeDefinition.MakeGenericType(elementType);
+            return (JsonConverter)Activator.CreateInstance(converterType)!;
+        }
+    }
+}

--- a/SerializationJson/LinearDiscriminantAnalysisJsonConverter.cs
+++ b/SerializationJson/LinearDiscriminantAnalysisJsonConverter.cs
@@ -1,0 +1,109 @@
+﻿using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using NumFlat.MultivariateAnalyses;
+
+namespace NumFlat.Serialization.Json
+{
+    /// <summary>
+    /// Converts <see cref="LinearDiscriminantAnalysis" /> instances to and from JSON.
+    /// </summary>
+    public sealed class LinearDiscriminantAnalysisJsonConverter : JsonConverter<LinearDiscriminantAnalysis>
+    {
+        private const string MeanPropertyName = "mean";
+        private const string EigenValuesPropertyName = "eigenValues";
+        private const string EigenVectorsPropertyName = "eigenVectors";
+
+        /// <inheritdoc />
+        public override LinearDiscriminantAnalysis Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            if (reader.TokenType != JsonTokenType.StartObject)
+            {
+                throw new JsonException("A NumFlat LDA object must be represented as a JSON object.");
+            }
+
+            Vec<double>? mean = null;
+            Vec<double>? eigenValues = null;
+            Mat<double>? eigenVectors = null;
+
+            while (reader.Read())
+            {
+                if (reader.TokenType == JsonTokenType.EndObject)
+                {
+                    if (mean == null)
+                    {
+                        throw new JsonException("The JSON object for a NumFlat LDA object must contain a 'mean' property.");
+                    }
+
+                    if (eigenValues == null)
+                    {
+                        throw new JsonException("The JSON object for a NumFlat LDA object must contain an 'eigenValues' property.");
+                    }
+
+                    if (eigenVectors == null)
+                    {
+                        throw new JsonException("The JSON object for a NumFlat LDA object must contain an 'eigenVectors' property.");
+                    }
+
+                    try
+                    {
+                        return new LinearDiscriminantAnalysis(mean.Value, eigenValues.Value, eigenVectors.Value);
+                    }
+                    catch (ArgumentException ex)
+                    {
+                        throw new JsonException("The JSON object cannot be converted to a NumFlat LDA object.", ex);
+                    }
+                }
+
+                if (reader.TokenType != JsonTokenType.PropertyName)
+                {
+                    throw new JsonException("A NumFlat LDA object property name is expected.");
+                }
+
+                var propertyName = reader.GetString();
+                if (!reader.Read())
+                {
+                    throw new JsonException("The JSON object for a NumFlat LDA object is incomplete.");
+                }
+
+                if (StringEquals(propertyName, MeanPropertyName, options))
+                {
+                    mean = JsonSerializer.Deserialize<Vec<double>>(ref reader, options);
+                }
+                else if (StringEquals(propertyName, EigenValuesPropertyName, options))
+                {
+                    eigenValues = JsonSerializer.Deserialize<Vec<double>>(ref reader, options);
+                }
+                else if (StringEquals(propertyName, EigenVectorsPropertyName, options))
+                {
+                    eigenVectors = JsonSerializer.Deserialize<Mat<double>>(ref reader, options);
+                }
+                else
+                {
+                    reader.Skip();
+                }
+            }
+
+            throw new JsonException("The JSON object for a NumFlat LDA object is incomplete.");
+        }
+
+        /// <inheritdoc />
+        public override void Write(Utf8JsonWriter writer, LinearDiscriminantAnalysis value, JsonSerializerOptions options)
+        {
+            writer.WriteStartObject();
+            writer.WritePropertyName(MeanPropertyName);
+            JsonSerializer.Serialize(writer, value.Mean, options);
+            writer.WritePropertyName(EigenValuesPropertyName);
+            JsonSerializer.Serialize(writer, value.EigenValues, options);
+            writer.WritePropertyName(EigenVectorsPropertyName);
+            JsonSerializer.Serialize(writer, value.EigenVectors, options);
+            writer.WriteEndObject();
+        }
+
+        private static bool StringEquals(string? value, string expected, JsonSerializerOptions options)
+        {
+            var comparison = options.PropertyNameCaseInsensitive ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
+            return string.Equals(value, expected, comparison);
+        }
+    }
+}

--- a/SerializationJson/LinearDiscriminantAnalysisJsonConverter.cs
+++ b/SerializationJson/LinearDiscriminantAnalysisJsonConverter.cs
@@ -10,100 +10,38 @@ namespace NumFlat.Serialization.Json
     /// </summary>
     public sealed class LinearDiscriminantAnalysisJsonConverter : JsonConverter<LinearDiscriminantAnalysis>
     {
-        private const string MeanPropertyName = "mean";
-        private const string EigenValuesPropertyName = "eigenValues";
-        private const string EigenVectorsPropertyName = "eigenVectors";
+        private const string ModelName = "LDA";
 
         /// <inheritdoc />
         public override LinearDiscriminantAnalysis Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
-            if (reader.TokenType != JsonTokenType.StartObject)
-            {
-                throw new JsonException("A NumFlat LDA object must be represented as a JSON object.");
-            }
-
-            Vec<double>? mean = null;
-            Vec<double>? eigenValues = null;
-            Mat<double>? eigenVectors = null;
-
-            while (reader.Read())
-            {
-                if (reader.TokenType == JsonTokenType.EndObject)
-                {
-                    if (mean == null)
-                    {
-                        throw new JsonException("The JSON object for a NumFlat LDA object must contain a 'mean' property.");
-                    }
-
-                    if (eigenValues == null)
-                    {
-                        throw new JsonException("The JSON object for a NumFlat LDA object must contain an 'eigenValues' property.");
-                    }
-
-                    if (eigenVectors == null)
-                    {
-                        throw new JsonException("The JSON object for a NumFlat LDA object must contain an 'eigenVectors' property.");
-                    }
-
-                    try
-                    {
-                        return new LinearDiscriminantAnalysis(mean.Value, eigenValues.Value, eigenVectors.Value);
-                    }
-                    catch (ArgumentException ex)
-                    {
-                        throw new JsonException("The JSON object cannot be converted to a NumFlat LDA object.", ex);
-                    }
-                }
-
-                if (reader.TokenType != JsonTokenType.PropertyName)
-                {
-                    throw new JsonException("A NumFlat LDA object property name is expected.");
-                }
-
-                var propertyName = reader.GetString();
-                if (!reader.Read())
-                {
-                    throw new JsonException("The JSON object for a NumFlat LDA object is incomplete.");
-                }
-
-                if (StringEquals(propertyName, MeanPropertyName, options))
-                {
-                    mean = JsonSerializer.Deserialize<Vec<double>>(ref reader, options);
-                }
-                else if (StringEquals(propertyName, EigenValuesPropertyName, options))
-                {
-                    eigenValues = JsonSerializer.Deserialize<Vec<double>>(ref reader, options);
-                }
-                else if (StringEquals(propertyName, EigenVectorsPropertyName, options))
-                {
-                    eigenVectors = JsonSerializer.Deserialize<Mat<double>>(ref reader, options);
-                }
-                else
-                {
-                    reader.Skip();
-                }
-            }
-
-            throw new JsonException("The JSON object for a NumFlat LDA object is incomplete.");
+            return EigenTransformJsonConverterCore.Read(ref reader, options, ModelName, CreateTransform);
         }
 
         /// <inheritdoc />
         public override void Write(Utf8JsonWriter writer, LinearDiscriminantAnalysis value, JsonSerializerOptions options)
         {
-            writer.WriteStartObject();
-            writer.WritePropertyName(MeanPropertyName);
-            JsonSerializer.Serialize(writer, value.Mean, options);
-            writer.WritePropertyName(EigenValuesPropertyName);
-            JsonSerializer.Serialize(writer, value.EigenValues, options);
-            writer.WritePropertyName(EigenVectorsPropertyName);
-            JsonSerializer.Serialize(writer, value.EigenVectors, options);
-            writer.WriteEndObject();
+            EigenTransformJsonConverterCore.Write(writer, value, options, GetMean, GetEigenValues, GetEigenVectors);
         }
 
-        private static bool StringEquals(string? value, string expected, JsonSerializerOptions options)
+        private static LinearDiscriminantAnalysis CreateTransform(Vec<double> mean, Vec<double> eigenValues, Mat<double> eigenVectors)
         {
-            var comparison = options.PropertyNameCaseInsensitive ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
-            return string.Equals(value, expected, comparison);
+            return new LinearDiscriminantAnalysis(mean, eigenValues, eigenVectors);
+        }
+
+        private static Vec<double> GetMean(LinearDiscriminantAnalysis value)
+        {
+            return value.Mean;
+        }
+
+        private static Vec<double> GetEigenValues(LinearDiscriminantAnalysis value)
+        {
+            return value.EigenValues;
+        }
+
+        private static Mat<double> GetEigenVectors(LinearDiscriminantAnalysis value)
+        {
+            return value.EigenVectors;
         }
     }
 }

--- a/SerializationJson/MatJsonConverterFactory.cs
+++ b/SerializationJson/MatJsonConverterFactory.cs
@@ -24,8 +24,7 @@ namespace NumFlat.Serialization.Json
         public override JsonConverter CreateConverter(Type typeToConvert, JsonSerializerOptions options)
         {
             var elementType = typeToConvert.GetGenericArguments()[0];
-            var converterType = typeof(MatJsonConverter<>).MakeGenericType(elementType);
-            return (JsonConverter)Activator.CreateInstance(converterType)!;
+            return JsonSerializationHelpers.CreateGenericConverter(typeof(MatJsonConverter<>), elementType);
         }
     }
 }

--- a/SerializationJson/NumFlatJsonSerializerOptionsExtensions.cs
+++ b/SerializationJson/NumFlatJsonSerializerOptionsExtensions.cs
@@ -28,6 +28,7 @@ namespace NumFlat.Serialization.Json
             AddConverterIfMissing<VecJsonConverterFactory>(options);
             AddConverterIfMissing<MatJsonConverterFactory>(options);
             AddConverterIfMissing<PrincipalComponentAnalysisJsonConverter>(options);
+            AddConverterIfMissing<LinearDiscriminantAnalysisJsonConverter>(options);
             return options;
         }
 

--- a/SerializationJson/NumFlatJsonSerializerOptionsExtensions.cs
+++ b/SerializationJson/NumFlatJsonSerializerOptionsExtensions.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Text.Json;
-using System.Text.Json.Serialization;
 
 namespace NumFlat.Serialization.Json
 {
@@ -25,25 +24,11 @@ namespace NumFlat.Serialization.Json
                 throw new ArgumentNullException(nameof(options));
             }
 
-            AddConverterIfMissing<VecJsonConverterFactory>(options);
-            AddConverterIfMissing<MatJsonConverterFactory>(options);
-            AddConverterIfMissing<PrincipalComponentAnalysisJsonConverter>(options);
-            AddConverterIfMissing<LinearDiscriminantAnalysisJsonConverter>(options);
+            JsonSerializationHelpers.AddConverterIfMissing<VecJsonConverterFactory>(options);
+            JsonSerializationHelpers.AddConverterIfMissing<MatJsonConverterFactory>(options);
+            JsonSerializationHelpers.AddConverterIfMissing<PrincipalComponentAnalysisJsonConverter>(options);
+            JsonSerializationHelpers.AddConverterIfMissing<LinearDiscriminantAnalysisJsonConverter>(options);
             return options;
-        }
-
-        private static void AddConverterIfMissing<TConverter>(JsonSerializerOptions options)
-            where TConverter : JsonConverter, new()
-        {
-            foreach (var converter in options.Converters)
-            {
-                if (converter.GetType() == typeof(TConverter))
-                {
-                    return;
-                }
-            }
-
-            options.Converters.Add(new TConverter());
         }
     }
 }

--- a/SerializationJson/PrincipalComponentAnalysisJsonConverter.cs
+++ b/SerializationJson/PrincipalComponentAnalysisJsonConverter.cs
@@ -10,100 +10,38 @@ namespace NumFlat.Serialization.Json
     /// </summary>
     public sealed class PrincipalComponentAnalysisJsonConverter : JsonConverter<PrincipalComponentAnalysis>
     {
-        private const string MeanPropertyName = "mean";
-        private const string EigenValuesPropertyName = "eigenValues";
-        private const string EigenVectorsPropertyName = "eigenVectors";
+        private const string ModelName = "PCA";
 
         /// <inheritdoc />
         public override PrincipalComponentAnalysis Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
-            if (reader.TokenType != JsonTokenType.StartObject)
-            {
-                throw new JsonException("A NumFlat PCA object must be represented as a JSON object.");
-            }
-
-            Vec<double>? mean = null;
-            Vec<double>? eigenValues = null;
-            Mat<double>? eigenVectors = null;
-
-            while (reader.Read())
-            {
-                if (reader.TokenType == JsonTokenType.EndObject)
-                {
-                    if (mean == null)
-                    {
-                        throw new JsonException("The JSON object for a NumFlat PCA object must contain a 'mean' property.");
-                    }
-
-                    if (eigenValues == null)
-                    {
-                        throw new JsonException("The JSON object for a NumFlat PCA object must contain an 'eigenValues' property.");
-                    }
-
-                    if (eigenVectors == null)
-                    {
-                        throw new JsonException("The JSON object for a NumFlat PCA object must contain an 'eigenVectors' property.");
-                    }
-
-                    try
-                    {
-                        return new PrincipalComponentAnalysis(mean.Value, eigenValues.Value, eigenVectors.Value);
-                    }
-                    catch (ArgumentException ex)
-                    {
-                        throw new JsonException("The JSON object cannot be converted to a NumFlat PCA object.", ex);
-                    }
-                }
-
-                if (reader.TokenType != JsonTokenType.PropertyName)
-                {
-                    throw new JsonException("A NumFlat PCA object property name is expected.");
-                }
-
-                var propertyName = reader.GetString();
-                if (!reader.Read())
-                {
-                    throw new JsonException("The JSON object for a NumFlat PCA object is incomplete.");
-                }
-
-                if (StringEquals(propertyName, MeanPropertyName, options))
-                {
-                    mean = JsonSerializer.Deserialize<Vec<double>>(ref reader, options);
-                }
-                else if (StringEquals(propertyName, EigenValuesPropertyName, options))
-                {
-                    eigenValues = JsonSerializer.Deserialize<Vec<double>>(ref reader, options);
-                }
-                else if (StringEquals(propertyName, EigenVectorsPropertyName, options))
-                {
-                    eigenVectors = JsonSerializer.Deserialize<Mat<double>>(ref reader, options);
-                }
-                else
-                {
-                    reader.Skip();
-                }
-            }
-
-            throw new JsonException("The JSON object for a NumFlat PCA object is incomplete.");
+            return EigenTransformJsonConverterCore.Read(ref reader, options, ModelName, CreateTransform);
         }
 
         /// <inheritdoc />
         public override void Write(Utf8JsonWriter writer, PrincipalComponentAnalysis value, JsonSerializerOptions options)
         {
-            writer.WriteStartObject();
-            writer.WritePropertyName(MeanPropertyName);
-            JsonSerializer.Serialize(writer, value.Mean, options);
-            writer.WritePropertyName(EigenValuesPropertyName);
-            JsonSerializer.Serialize(writer, value.EigenValues, options);
-            writer.WritePropertyName(EigenVectorsPropertyName);
-            JsonSerializer.Serialize(writer, value.EigenVectors, options);
-            writer.WriteEndObject();
+            EigenTransformJsonConverterCore.Write(writer, value, options, GetMean, GetEigenValues, GetEigenVectors);
         }
 
-        private static bool StringEquals(string? value, string expected, JsonSerializerOptions options)
+        private static PrincipalComponentAnalysis CreateTransform(Vec<double> mean, Vec<double> eigenValues, Mat<double> eigenVectors)
         {
-            var comparison = options.PropertyNameCaseInsensitive ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
-            return string.Equals(value, expected, comparison);
+            return new PrincipalComponentAnalysis(mean, eigenValues, eigenVectors);
+        }
+
+        private static Vec<double> GetMean(PrincipalComponentAnalysis value)
+        {
+            return value.Mean;
+        }
+
+        private static Vec<double> GetEigenValues(PrincipalComponentAnalysis value)
+        {
+            return value.EigenValues;
+        }
+
+        private static Mat<double> GetEigenVectors(PrincipalComponentAnalysis value)
+        {
+            return value.EigenVectors;
         }
     }
 }

--- a/SerializationJson/VecJsonConverterFactory.cs
+++ b/SerializationJson/VecJsonConverterFactory.cs
@@ -24,8 +24,7 @@ namespace NumFlat.Serialization.Json
         public override JsonConverter CreateConverter(Type typeToConvert, JsonSerializerOptions options)
         {
             var elementType = typeToConvert.GetGenericArguments()[0];
-            var converterType = typeof(VecJsonConverter<>).MakeGenericType(elementType);
-            return (JsonConverter)Activator.CreateInstance(converterType)!;
+            return JsonSerializationHelpers.CreateGenericConverter(typeof(VecJsonConverter<>), elementType);
         }
     }
 }

--- a/SerializationJsonTest/LinearDiscriminantAnalysisTests.cs
+++ b/SerializationJsonTest/LinearDiscriminantAnalysisTests.cs
@@ -43,6 +43,20 @@ namespace SerializationJsonTest
         }
 
         [Test]
+        public void DeserializeLdaHonorsCaseInsensitivePropertyNames()
+        {
+            var options = NumFlatJsonSerializerOptions.Create();
+            options.PropertyNameCaseInsensitive = true;
+            const string json = "{\"Mean\":[1,2],\"EigenValues\":[3,4],\"EigenVectors\":[[0,1],[1,0]]}";
+
+            var actual = JsonSerializer.Deserialize<LinearDiscriminantAnalysis>(json, options)!;
+
+            Assert.That(actual.Mean.ToArray(), Is.EqualTo(new[] { 1.0, 2.0 }));
+            Assert.That(actual.EigenValues.ToArray(), Is.EqualTo(new[] { 3.0, 4.0 }));
+            Assert.That(actual.EigenVectors[0, 1], Is.EqualTo(1.0));
+        }
+
+        [Test]
         public void DeserializeLdaWithInvalidShapeThrowsJsonException()
         {
             var options = NumFlatJsonSerializerOptions.Create();

--- a/SerializationJsonTest/LinearDiscriminantAnalysisTests.cs
+++ b/SerializationJsonTest/LinearDiscriminantAnalysisTests.cs
@@ -1,0 +1,77 @@
+using System;
+using System.Linq;
+using System.Text.Json;
+using NumFlat;
+using NumFlat.MultivariateAnalyses;
+using NumFlat.Serialization.Json;
+
+namespace SerializationJsonTest
+{
+    public class LinearDiscriminantAnalysisTests
+    {
+        [Test]
+        public void RoundTripLdaKeepsFittedParameters()
+        {
+            var options = NumFlatJsonSerializerOptions.Create();
+            var source = CreateLda();
+
+            var json = JsonSerializer.Serialize(source, options);
+            var actual = JsonSerializer.Deserialize<LinearDiscriminantAnalysis>(json, options)!;
+
+            Assert.That(json, Is.EqualTo("{\"mean\":[1,2],\"eigenValues\":[3,4],\"eigenVectors\":[[0,1],[1,0]]}"));
+            Assert.That(actual.Mean.ToArray(), Is.EqualTo(new[] { 1.0, 2.0 }));
+            Assert.That(actual.EigenValues.ToArray(), Is.EqualTo(new[] { 3.0, 4.0 }));
+            Assert.That(actual.EigenVectors[0, 0], Is.EqualTo(0.0));
+            Assert.That(actual.EigenVectors[0, 1], Is.EqualTo(1.0));
+            Assert.That(actual.EigenVectors[1, 0], Is.EqualTo(1.0));
+            Assert.That(actual.EigenVectors[1, 1], Is.EqualTo(0.0));
+        }
+
+        [Test]
+        public void RoundTripLdaKeepsTransformBehavior()
+        {
+            var options = NumFlatJsonSerializerOptions.Create();
+            var source = CreateLda();
+            var x = new Vec<double>(new[] { 5.0, 7.0 });
+            var expected = source.Transform(x);
+
+            var json = JsonSerializer.Serialize(source, options);
+            var actual = JsonSerializer.Deserialize<LinearDiscriminantAnalysis>(json, options)!;
+            var actualTransformed = actual.Transform(x);
+
+            Assert.That(actualTransformed.ToArray(), Is.EqualTo(expected.ToArray()).Within(1.0e-12));
+        }
+
+        [Test]
+        public void DeserializeLdaWithInvalidShapeThrowsJsonException()
+        {
+            var options = NumFlatJsonSerializerOptions.Create();
+            const string json = "{\"mean\":[1,2],\"eigenValues\":[3],\"eigenVectors\":[[1,0],[0,1]]}";
+
+            Assert.That((Action)(() => JsonSerializer.Deserialize<LinearDiscriminantAnalysis>(json, options)), Throws.TypeOf<JsonException>());
+        }
+
+        [Test]
+        public void AddNumFlatConvertersAddsLdaConverterOnce()
+        {
+            var options = new JsonSerializerOptions();
+
+            options.AddNumFlatConverters().AddNumFlatConverters();
+
+            Assert.That(options.Converters.OfType<LinearDiscriminantAnalysisJsonConverter>().Count(), Is.EqualTo(1));
+        }
+
+        private static LinearDiscriminantAnalysis CreateLda()
+        {
+            var mean = new Vec<double>(new[] { 1.0, 2.0 });
+            var eigenValues = new Vec<double>(new[] { 3.0, 4.0 });
+            var eigenVectors = new Mat<double>(2, 2, 2, new[]
+            {
+                0.0, 1.0,
+                1.0, 0.0
+            });
+
+            return new LinearDiscriminantAnalysis(mean, eigenValues, eigenVectors);
+        }
+    }
+}

--- a/SerializationJsonTest/LinearDiscriminantAnalysisTests.cs
+++ b/SerializationJsonTest/LinearDiscriminantAnalysisTests.cs
@@ -51,16 +51,6 @@ namespace SerializationJsonTest
             Assert.That((Action)(() => JsonSerializer.Deserialize<LinearDiscriminantAnalysis>(json, options)), Throws.TypeOf<JsonException>());
         }
 
-        [Test]
-        public void AddNumFlatConvertersAddsLdaConverterOnce()
-        {
-            var options = new JsonSerializerOptions();
-
-            options.AddNumFlatConverters().AddNumFlatConverters();
-
-            Assert.That(options.Converters.OfType<LinearDiscriminantAnalysisJsonConverter>().Count(), Is.EqualTo(1));
-        }
-
         private static LinearDiscriminantAnalysis CreateLda()
         {
             var mean = new Vec<double>(new[] { 1.0, 2.0 });

--- a/SerializationJsonTest/NumFlatJsonSerializerOptionsTests.cs
+++ b/SerializationJsonTest/NumFlatJsonSerializerOptionsTests.cs
@@ -1,0 +1,22 @@
+using System.Linq;
+using System.Text.Json;
+using NumFlat.Serialization.Json;
+
+namespace SerializationJsonTest
+{
+    public class NumFlatJsonSerializerOptionsTests
+    {
+        [Test]
+        public void AddNumFlatConvertersDoesNotAddDuplicates()
+        {
+            var options = new JsonSerializerOptions();
+
+            options.AddNumFlatConverters().AddNumFlatConverters();
+
+            Assert.That(options.Converters.OfType<VecJsonConverterFactory>().Count(), Is.EqualTo(1));
+            Assert.That(options.Converters.OfType<MatJsonConverterFactory>().Count(), Is.EqualTo(1));
+            Assert.That(options.Converters.OfType<PrincipalComponentAnalysisJsonConverter>().Count(), Is.EqualTo(1));
+            Assert.That(options.Converters.OfType<LinearDiscriminantAnalysisJsonConverter>().Count(), Is.EqualTo(1));
+        }
+    }
+}

--- a/SerializationJsonTest/PrincipalComponentAnalysisTests.cs
+++ b/SerializationJsonTest/PrincipalComponentAnalysisTests.cs
@@ -53,16 +53,6 @@ namespace SerializationJsonTest
             Assert.That((Action)(() => JsonSerializer.Deserialize<PrincipalComponentAnalysis>(json, options)), Throws.TypeOf<JsonException>());
         }
 
-        [Test]
-        public void AddNumFlatConvertersAddsPcaConverterOnce()
-        {
-            var options = new JsonSerializerOptions();
-
-            options.AddNumFlatConverters().AddNumFlatConverters();
-
-            Assert.That(options.Converters.OfType<PrincipalComponentAnalysisJsonConverter>().Count(), Is.EqualTo(1));
-        }
-
         private static PrincipalComponentAnalysis CreatePca()
         {
             var mean = new Vec<double>(new[] { 1.0, 2.0 });

--- a/SerializationJsonTest/VectorMatrixTests.cs
+++ b/SerializationJsonTest/VectorMatrixTests.cs
@@ -142,6 +142,7 @@ namespace SerializationJsonTest
             Assert.That(options.Converters.OfType<VecJsonConverterFactory>().Count(), Is.EqualTo(1));
             Assert.That(options.Converters.OfType<MatJsonConverterFactory>().Count(), Is.EqualTo(1));
             Assert.That(options.Converters.OfType<PrincipalComponentAnalysisJsonConverter>().Count(), Is.EqualTo(1));
+            Assert.That(options.Converters.OfType<LinearDiscriminantAnalysisJsonConverter>().Count(), Is.EqualTo(1));
         }
     }
 }

--- a/SerializationJsonTest/VectorMatrixTests.cs
+++ b/SerializationJsonTest/VectorMatrixTests.cs
@@ -131,18 +131,5 @@ namespace SerializationJsonTest
             Assert.That((Action)(() => JsonSerializer.Deserialize<Mat<int>>("[[]]", options)), Throws.TypeOf<JsonException>());
             Assert.That((Action)(() => JsonSerializer.Deserialize<Mat<int>>("[[1,2],[3]]", options)), Throws.TypeOf<JsonException>());
         }
-
-        [Test]
-        public void AddNumFlatConvertersDoesNotAddDuplicates()
-        {
-            var options = new JsonSerializerOptions();
-
-            options.AddNumFlatConverters().AddNumFlatConverters();
-
-            Assert.That(options.Converters.OfType<VecJsonConverterFactory>().Count(), Is.EqualTo(1));
-            Assert.That(options.Converters.OfType<MatJsonConverterFactory>().Count(), Is.EqualTo(1));
-            Assert.That(options.Converters.OfType<PrincipalComponentAnalysisJsonConverter>().Count(), Is.EqualTo(1));
-            Assert.That(options.Converters.OfType<LinearDiscriminantAnalysisJsonConverter>().Count(), Is.EqualTo(1));
-        }
     }
 }


### PR DESCRIPTION
### Motivation
- Provide JSON serialization/deserialization for `LinearDiscriminantAnalysis` using the same shape as PCA (`mean`, `eigenValues`, `eigenVectors`).
- Allow deserializers to reconstruct a fitted LDA instance from persisted parameters by storing fitted parameters directly instead of a GEVD object.

### Description
- Added a fitted-parameter constructor `public LinearDiscriminantAnalysis(in Vec<double> mean, in Vec<double> eigenValues, in Mat<double> eigenVectors)` and replaced the internal GEVD storage with `eigenValues` and `eigenVectors` fields in `NumFlat/MultivariateAnalyses/LinearDiscriminantAnalysis.cs` so instances can be reconstructed from saved parameters.
- Added `SerializationJson/LinearDiscriminantAnalysisJsonConverter.cs` to serialize/deserialize LDA objects with properties `mean`, `eigenValues`, and `eigenVectors`, mirroring `PrincipalComponentAnalysis` behavior.
- Registered the new converter in `SerializationJson/NumFlatJsonSerializerOptionsExtensions.cs` via `AddNumFlatConverters()`.
- Added tests `SerializationJsonTest/LinearDiscriminantAnalysisTests.cs` and updated `SerializationJsonTest/VectorMatrixTests.cs` to include LDA converter checks, covering round-trip serialization, transform behavior preservation, invalid-shape error, and duplicate-registration prevention.

### Testing
- Ran `dotnet format SerializationJsonTest/SerializationJsonTest.csproj --verify-no-changes --verbosity quiet`, which completed successfully.
- Ran `dotnet test SerializationJsonTest/SerializationJsonTest.csproj`, which passed (18 tests).
- Ran `dotnet test NumFlatTest/NumFlatTest.csproj`, which passed (3521 tests).
- Attempted `dotnet test NumFlat.slnx`, which failed in this environment because the `.slnx` format is not supported by the local MSBuild/CLI.
- A repo-root `dotnet format --verify-no-changes`/global format check failed here due to workspace/project discovery limitations in this environment, not due to code changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a068fb93ac48326ab1a95ae09a6251e)