### PR TITLE
Add JSON converter for System.Numerics.Complex and tests

### DIFF
--- a/SerializationJson/ComplexJsonConverter.cs
+++ b/SerializationJson/ComplexJsonConverter.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Numerics;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace NumFlat.Serialization.Json
+{
+    internal sealed class ComplexJsonConverter : JsonConverter<Complex>
+    {
+        public override Complex Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            if (reader.TokenType != JsonTokenType.StartArray)
+            {
+                throw new JsonException("A complex value must be represented as a [real, imaginary] array.");
+            }
+
+            if (!reader.Read())
+            {
+                throw new JsonException("The JSON array for a complex value is incomplete.");
+            }
+            var real = reader.GetDouble();
+
+            if (!reader.Read())
+            {
+                throw new JsonException("The JSON array for a complex value is incomplete.");
+            }
+            var imaginary = reader.GetDouble();
+
+            if (!reader.Read() || reader.TokenType != JsonTokenType.EndArray)
+            {
+                throw new JsonException("A complex value array must contain exactly two numbers.");
+            }
+
+            return new Complex(real, imaginary);
+        }
+
+        public override void Write(Utf8JsonWriter writer, Complex value, JsonSerializerOptions options)
+        {
+            writer.WriteStartArray();
+            writer.WriteNumberValue(value.Real);
+            writer.WriteNumberValue(value.Imaginary);
+            writer.WriteEndArray();
+        }
+    }
+}

--- a/SerializationJson/NumFlatJsonSerializerOptionsExtensions.cs
+++ b/SerializationJson/NumFlatJsonSerializerOptionsExtensions.cs
@@ -24,6 +24,7 @@ namespace NumFlat.Serialization.Json
                 throw new ArgumentNullException(nameof(options));
             }
 
+            JsonSerializationHelpers.AddConverterIfMissing<ComplexJsonConverter>(options);
             JsonSerializationHelpers.AddConverterIfMissing<VecJsonConverterFactory>(options);
             JsonSerializationHelpers.AddConverterIfMissing<MatJsonConverterFactory>(options);
             JsonSerializationHelpers.AddConverterIfMissing<PrincipalComponentAnalysisJsonConverter>(options);

--- a/SerializationJsonTest/VectorMatrixTests.cs
+++ b/SerializationJsonTest/VectorMatrixTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Linq;
+using System.Numerics;
 using System.Text.Json;
 using NumFlat;
 using NumFlat.Serialization.Json;
@@ -121,6 +122,89 @@ namespace SerializationJsonTest
             Assert.That(actual.IsEmpty, Is.True);
             Assert.That(actual.RowCount, Is.EqualTo(0));
             Assert.That(actual.ColCount, Is.EqualTo(0));
+        }
+
+        [Test]
+        public void RoundTripComplexUsesArrayShape()
+        {
+            var options = new JsonSerializerOptions().AddNumFlatConverters();
+            var source = new Complex(1.25, -2.5);
+
+            var json = JsonSerializer.Serialize(source, options);
+            var actual = JsonSerializer.Deserialize<Complex>(json, options);
+
+            Assert.That(json, Is.EqualTo("[1.25,-2.5]"));
+            Assert.That(actual, Is.EqualTo(source));
+        }
+
+        [Test]
+        public void RoundTripComplexVectorUsesArrayOfPairsShape()
+        {
+            var options = new JsonSerializerOptions().AddNumFlatConverters();
+            var source = new Vec<Complex>(3, 2, new[]
+            {
+                new Complex(1.25, -2.5),
+                default,
+                new Complex(3.5, 4.75),
+                default,
+                new Complex(-5.125, 6.25),
+            });
+
+            var json = JsonSerializer.Serialize(source, options);
+            var actual = JsonSerializer.Deserialize<Vec<Complex>>(json, options);
+
+            Assert.That(json, Is.EqualTo("[[1.25,-2.5],[3.5,4.75],[-5.125,6.25]]"));
+            Assert.That(actual.Count, Is.EqualTo(3));
+            Assert.That(actual.Stride, Is.EqualTo(1));
+            Assert.That(actual.ToArray(), Is.EqualTo(new[]
+            {
+                new Complex(1.25, -2.5),
+                new Complex(3.5, 4.75),
+                new Complex(-5.125, 6.25),
+            }));
+        }
+
+        [Test]
+        public void RoundTripComplexMatrixUsesArrayOfRowsShape()
+        {
+            var options = new JsonSerializerOptions().AddNumFlatConverters();
+            var source = new Mat<Complex>(2, 2, 3, new[]
+            {
+                new Complex(1.25, -2.5),
+                new Complex(3.5, 4.75),
+                default,
+                new Complex(-5.125, 6.25),
+                new Complex(7.5, -8.75),
+            });
+
+            var json = JsonSerializer.Serialize(source, options);
+            var actual = JsonSerializer.Deserialize<Mat<Complex>>(json, options);
+
+            Assert.That(json, Is.EqualTo("[[[1.25,-2.5],[-5.125,6.25]],[[3.5,4.75],[7.5,-8.75]]]"));
+            Assert.That(actual.RowCount, Is.EqualTo(2));
+            Assert.That(actual.ColCount, Is.EqualTo(2));
+            Assert.That(actual.Stride, Is.EqualTo(2));
+            Assert.That(actual[0, 0], Is.EqualTo(new Complex(1.25, -2.5)));
+            Assert.That(actual[0, 1], Is.EqualTo(new Complex(-5.125, 6.25)));
+            Assert.That(actual[1, 0], Is.EqualTo(new Complex(3.5, 4.75)));
+            Assert.That(actual[1, 1], Is.EqualTo(new Complex(7.5, -8.75)));
+        }
+
+        [Test]
+        public void DeserializeComplexVectorAndMatrixArrays()
+        {
+            var options = new JsonSerializerOptions().AddNumFlatConverters();
+
+            var vector = JsonSerializer.Deserialize<Vec<Complex>>("[[1,2],[3,4]]", options);
+            var matrix = JsonSerializer.Deserialize<Mat<Complex>>("[[[1,2],[3,4]],[[5,6],[7,8]]]", options);
+
+            Assert.That(vector.ToArray(), Is.EqualTo(new[] { new Complex(1, 2), new Complex(3, 4) }));
+            Assert.That(matrix.RowCount, Is.EqualTo(2));
+            Assert.That(matrix.ColCount, Is.EqualTo(2));
+            Assert.That(matrix[0, 0], Is.EqualTo(new Complex(1, 2)));
+            Assert.That(matrix[0, 1], Is.EqualTo(new Complex(3, 4)));
+            Assert.That(matrix[1, 0], Is.EqualTo(new Complex(5, 6)));
+            Assert.That(matrix[1, 1], Is.EqualTo(new Complex(7, 8)));
         }
 
         [Test]


### PR DESCRIPTION
### Motivation
- Support serializing and deserializing `System.Numerics.Complex` values so complex scalars, vectors, and matrices can be round-tripped in the NumFlat JSON representation.
- Ensure complex numbers are represented consistently as `[real, imaginary]` arrays to match vector/matrix shapes used elsewhere.

### Description
- Add `ComplexJsonConverter` that reads and writes a `Complex` as a two-element JSON array `[real, imaginary]` and validates array shape during read.
- Register the converter in `AddNumFlatConverters` using `JsonSerializationHelpers.AddConverterIfMissing<ComplexJsonConverter>(options)`.
- Add unit tests to `VectorMatrixTests` covering scalar round-trip (`RoundTripComplexUsesArrayShape`), vector round-trip (`RoundTripComplexVectorUsesArrayOfPairsShape`), matrix round-trip (`RoundTripComplexMatrixUsesArrayOfRowsShape`), and deserialization of nested arrays (`DeserializeComplexVectorAndMatrixArrays`).
- Add `using System.Numerics` to the test file to enable `Complex` usage.

### Testing
- Ran the serialization unit test suite (including the new tests in `VectorMatrixTests`) via the project test runner, and all tests passed successfully.
- The new tests exercised serialization and deserialization of `Complex`, `Vec<Complex>`, and `Mat<Complex>` and validated JSON shape strings and reconstructed values.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a06989380548326b72bf424e809d0c4)