### PR TITLE
Add JSON converters and deserialization constructors for regression models with tests

### DIFF
--- a/NumFlat/MultivariateAnalyses/ComplexLinearRegression.cs
+++ b/NumFlat/MultivariateAnalyses/ComplexLinearRegression.cs
@@ -114,6 +114,27 @@ namespace NumFlat.MultivariateAnalyses
             this.intercept = a[0];
         }
 
+        /// <summary>
+        /// Creates complex linear regression from fitted parameters.
+        /// </summary>
+        /// <param name="coefficients">
+        /// The coefficients.
+        /// </param>
+        /// <param name="intercept">
+        /// The bias term.
+        /// </param>
+        /// <remarks>
+        /// This constructor is intended primarily for deserializers that reconstruct a fitted model from persisted parameters.
+        /// The given vector is stored directly, so it should not be mutated after construction.
+        /// </remarks>
+        public ComplexLinearRegression(in Vec<Complex> coefficients, Complex intercept)
+        {
+            ThrowHelper.ThrowIfEmpty(coefficients, nameof(coefficients));
+
+            this.coefficients = coefficients;
+            this.intercept = intercept;
+        }
+
         /// <inheritdoc/>
         public Complex Transform(in Vec<Complex> source)
         {

--- a/NumFlat/MultivariateAnalyses/LinearRegression.cs
+++ b/NumFlat/MultivariateAnalyses/LinearRegression.cs
@@ -113,6 +113,27 @@ namespace NumFlat.MultivariateAnalyses
             this.intercept = a[0];
         }
 
+        /// <summary>
+        /// Creates linear regression from fitted parameters.
+        /// </summary>
+        /// <param name="coefficients">
+        /// The coefficients.
+        /// </param>
+        /// <param name="intercept">
+        /// The bias term.
+        /// </param>
+        /// <remarks>
+        /// This constructor is intended primarily for deserializers that reconstruct a fitted model from persisted parameters.
+        /// The given vector is stored directly, so it should not be mutated after construction.
+        /// </remarks>
+        public LinearRegression(in Vec<double> coefficients, double intercept)
+        {
+            ThrowHelper.ThrowIfEmpty(coefficients, nameof(coefficients));
+
+            this.coefficients = coefficients;
+            this.intercept = intercept;
+        }
+
         /// <inheritdoc/>
         public double Transform(in Vec<double> source)
         {

--- a/NumFlat/MultivariateAnalyses/LogisticRegression.cs
+++ b/NumFlat/MultivariateAnalyses/LogisticRegression.cs
@@ -164,6 +164,27 @@ namespace NumFlat.MultivariateAnalyses
             this.intercept = a[0];
         }
 
+        /// <summary>
+        /// Creates logistic regression from fitted parameters.
+        /// </summary>
+        /// <param name="coefficients">
+        /// The coefficients.
+        /// </param>
+        /// <param name="intercept">
+        /// The bias term.
+        /// </param>
+        /// <remarks>
+        /// This constructor is intended primarily for deserializers that reconstruct a fitted model from persisted parameters.
+        /// The given vector is stored directly, so it should not be mutated after construction.
+        /// </remarks>
+        public LogisticRegression(in Vec<double> coefficients, double intercept)
+        {
+            ThrowHelper.ThrowIfEmpty(coefficients, nameof(coefficients));
+
+            this.coefficients = coefficients;
+            this.intercept = intercept;
+        }
+
         private static double CrossEntropyLoss(in Vec<double> expected, in Vec<double> actual, double eps)
         {
             var sum = 0.0;

--- a/SerializationJson/ComplexLinearRegressionJsonConverter.cs
+++ b/SerializationJson/ComplexLinearRegressionJsonConverter.cs
@@ -1,0 +1,96 @@
+﻿using System;
+using System.Numerics;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using NumFlat.MultivariateAnalyses;
+
+namespace NumFlat.Serialization.Json
+{
+    /// <summary>
+    /// Converts <see cref="ComplexLinearRegression" /> instances to and from JSON.
+    /// </summary>
+    public sealed class ComplexLinearRegressionJsonConverter : JsonConverter<ComplexLinearRegression>
+    {
+        private const string CoefficientsPropertyName = "coefficients";
+        private const string InterceptPropertyName = "intercept";
+
+        /// <inheritdoc />
+        public override ComplexLinearRegression Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            if (reader.TokenType != JsonTokenType.StartObject)
+            {
+                throw new JsonException("A NumFlat complex linear regression object must be represented as a JSON object.");
+            }
+
+            Vec<Complex>? coefficients = null;
+            Complex? intercept = null;
+
+            while (reader.Read())
+            {
+                if (reader.TokenType == JsonTokenType.EndObject)
+                {
+                    return CreateComplexLinearRegression(coefficients, intercept);
+                }
+
+                if (reader.TokenType != JsonTokenType.PropertyName)
+                {
+                    throw new JsonException("A NumFlat complex linear regression object property name is expected.");
+                }
+
+                var propertyName = reader.GetString();
+                if (!reader.Read())
+                {
+                    throw new JsonException("The JSON object for a NumFlat complex linear regression object is incomplete.");
+                }
+
+                if (JsonSerializationHelpers.PropertyNameEquals(propertyName, CoefficientsPropertyName, options))
+                {
+                    coefficients = JsonSerializer.Deserialize<Vec<Complex>>(ref reader, options);
+                }
+                else if (JsonSerializationHelpers.PropertyNameEquals(propertyName, InterceptPropertyName, options))
+                {
+                    intercept = JsonSerializer.Deserialize<Complex>(ref reader, options);
+                }
+                else
+                {
+                    reader.Skip();
+                }
+            }
+
+            throw new JsonException("The JSON object for a NumFlat complex linear regression object is incomplete.");
+        }
+
+        /// <inheritdoc />
+        public override void Write(Utf8JsonWriter writer, ComplexLinearRegression value, JsonSerializerOptions options)
+        {
+            writer.WriteStartObject();
+            writer.WritePropertyName(CoefficientsPropertyName);
+            JsonSerializer.Serialize(writer, value.Coefficients, options);
+            writer.WritePropertyName(InterceptPropertyName);
+            JsonSerializer.Serialize(writer, value.Intercept, options);
+            writer.WriteEndObject();
+        }
+
+        private static ComplexLinearRegression CreateComplexLinearRegression(Vec<Complex>? coefficients, Complex? intercept)
+        {
+            if (coefficients == null)
+            {
+                throw new JsonException("The JSON object for a NumFlat complex linear regression object must contain a 'coefficients' property.");
+            }
+
+            if (intercept == null)
+            {
+                throw new JsonException("The JSON object for a NumFlat complex linear regression object must contain an 'intercept' property.");
+            }
+
+            try
+            {
+                return new ComplexLinearRegression(coefficients.Value, intercept.Value);
+            }
+            catch (ArgumentException ex)
+            {
+                throw new JsonException("The JSON object cannot be converted to a NumFlat complex linear regression object.", ex);
+            }
+        }
+    }
+}

--- a/SerializationJson/LinearRegressionJsonConverter.cs
+++ b/SerializationJson/LinearRegressionJsonConverter.cs
@@ -1,0 +1,95 @@
+﻿using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using NumFlat.MultivariateAnalyses;
+
+namespace NumFlat.Serialization.Json
+{
+    /// <summary>
+    /// Converts <see cref="LinearRegression" /> instances to and from JSON.
+    /// </summary>
+    public sealed class LinearRegressionJsonConverter : JsonConverter<LinearRegression>
+    {
+        private const string CoefficientsPropertyName = "coefficients";
+        private const string InterceptPropertyName = "intercept";
+
+        /// <inheritdoc />
+        public override LinearRegression Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            if (reader.TokenType != JsonTokenType.StartObject)
+            {
+                throw new JsonException("A NumFlat linear regression object must be represented as a JSON object.");
+            }
+
+            Vec<double>? coefficients = null;
+            double? intercept = null;
+
+            while (reader.Read())
+            {
+                if (reader.TokenType == JsonTokenType.EndObject)
+                {
+                    return CreateLinearRegression(coefficients, intercept);
+                }
+
+                if (reader.TokenType != JsonTokenType.PropertyName)
+                {
+                    throw new JsonException("A NumFlat linear regression object property name is expected.");
+                }
+
+                var propertyName = reader.GetString();
+                if (!reader.Read())
+                {
+                    throw new JsonException("The JSON object for a NumFlat linear regression object is incomplete.");
+                }
+
+                if (JsonSerializationHelpers.PropertyNameEquals(propertyName, CoefficientsPropertyName, options))
+                {
+                    coefficients = JsonSerializer.Deserialize<Vec<double>>(ref reader, options);
+                }
+                else if (JsonSerializationHelpers.PropertyNameEquals(propertyName, InterceptPropertyName, options))
+                {
+                    intercept = JsonSerializer.Deserialize<double>(ref reader, options);
+                }
+                else
+                {
+                    reader.Skip();
+                }
+            }
+
+            throw new JsonException("The JSON object for a NumFlat linear regression object is incomplete.");
+        }
+
+        /// <inheritdoc />
+        public override void Write(Utf8JsonWriter writer, LinearRegression value, JsonSerializerOptions options)
+        {
+            writer.WriteStartObject();
+            writer.WritePropertyName(CoefficientsPropertyName);
+            JsonSerializer.Serialize(writer, value.Coefficients, options);
+            writer.WritePropertyName(InterceptPropertyName);
+            JsonSerializer.Serialize(writer, value.Intercept, options);
+            writer.WriteEndObject();
+        }
+
+        private static LinearRegression CreateLinearRegression(Vec<double>? coefficients, double? intercept)
+        {
+            if (coefficients == null)
+            {
+                throw new JsonException("The JSON object for a NumFlat linear regression object must contain a 'coefficients' property.");
+            }
+
+            if (intercept == null)
+            {
+                throw new JsonException("The JSON object for a NumFlat linear regression object must contain an 'intercept' property.");
+            }
+
+            try
+            {
+                return new LinearRegression(coefficients.Value, intercept.Value);
+            }
+            catch (ArgumentException ex)
+            {
+                throw new JsonException("The JSON object cannot be converted to a NumFlat linear regression object.", ex);
+            }
+        }
+    }
+}

--- a/SerializationJson/LogisticRegressionJsonConverter.cs
+++ b/SerializationJson/LogisticRegressionJsonConverter.cs
@@ -1,0 +1,95 @@
+﻿using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using NumFlat.MultivariateAnalyses;
+
+namespace NumFlat.Serialization.Json
+{
+    /// <summary>
+    /// Converts <see cref="LogisticRegression" /> instances to and from JSON.
+    /// </summary>
+    public sealed class LogisticRegressionJsonConverter : JsonConverter<LogisticRegression>
+    {
+        private const string CoefficientsPropertyName = "coefficients";
+        private const string InterceptPropertyName = "intercept";
+
+        /// <inheritdoc />
+        public override LogisticRegression Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            if (reader.TokenType != JsonTokenType.StartObject)
+            {
+                throw new JsonException("A NumFlat logistic regression object must be represented as a JSON object.");
+            }
+
+            Vec<double>? coefficients = null;
+            double? intercept = null;
+
+            while (reader.Read())
+            {
+                if (reader.TokenType == JsonTokenType.EndObject)
+                {
+                    return CreateLogisticRegression(coefficients, intercept);
+                }
+
+                if (reader.TokenType != JsonTokenType.PropertyName)
+                {
+                    throw new JsonException("A NumFlat logistic regression object property name is expected.");
+                }
+
+                var propertyName = reader.GetString();
+                if (!reader.Read())
+                {
+                    throw new JsonException("The JSON object for a NumFlat logistic regression object is incomplete.");
+                }
+
+                if (JsonSerializationHelpers.PropertyNameEquals(propertyName, CoefficientsPropertyName, options))
+                {
+                    coefficients = JsonSerializer.Deserialize<Vec<double>>(ref reader, options);
+                }
+                else if (JsonSerializationHelpers.PropertyNameEquals(propertyName, InterceptPropertyName, options))
+                {
+                    intercept = JsonSerializer.Deserialize<double>(ref reader, options);
+                }
+                else
+                {
+                    reader.Skip();
+                }
+            }
+
+            throw new JsonException("The JSON object for a NumFlat logistic regression object is incomplete.");
+        }
+
+        /// <inheritdoc />
+        public override void Write(Utf8JsonWriter writer, LogisticRegression value, JsonSerializerOptions options)
+        {
+            writer.WriteStartObject();
+            writer.WritePropertyName(CoefficientsPropertyName);
+            JsonSerializer.Serialize(writer, value.Coefficients, options);
+            writer.WritePropertyName(InterceptPropertyName);
+            JsonSerializer.Serialize(writer, value.Intercept, options);
+            writer.WriteEndObject();
+        }
+
+        private static LogisticRegression CreateLogisticRegression(Vec<double>? coefficients, double? intercept)
+        {
+            if (coefficients == null)
+            {
+                throw new JsonException("The JSON object for a NumFlat logistic regression object must contain a 'coefficients' property.");
+            }
+
+            if (intercept == null)
+            {
+                throw new JsonException("The JSON object for a NumFlat logistic regression object must contain an 'intercept' property.");
+            }
+
+            try
+            {
+                return new LogisticRegression(coefficients.Value, intercept.Value);
+            }
+            catch (ArgumentException ex)
+            {
+                throw new JsonException("The JSON object cannot be converted to a NumFlat logistic regression object.", ex);
+            }
+        }
+    }
+}

--- a/SerializationJson/NumFlatJsonSerializerOptionsExtensions.cs
+++ b/SerializationJson/NumFlatJsonSerializerOptionsExtensions.cs
@@ -29,6 +29,9 @@ namespace NumFlat.Serialization.Json
             JsonSerializationHelpers.AddConverterIfMissing<MatJsonConverterFactory>(options);
             JsonSerializationHelpers.AddConverterIfMissing<PrincipalComponentAnalysisJsonConverter>(options);
             JsonSerializationHelpers.AddConverterIfMissing<LinearDiscriminantAnalysisJsonConverter>(options);
+            JsonSerializationHelpers.AddConverterIfMissing<LinearRegressionJsonConverter>(options);
+            JsonSerializationHelpers.AddConverterIfMissing<ComplexLinearRegressionJsonConverter>(options);
+            JsonSerializationHelpers.AddConverterIfMissing<LogisticRegressionJsonConverter>(options);
             return options;
         }
     }

--- a/SerializationJsonTest/ComplexLinearRegressionTests.cs
+++ b/SerializationJsonTest/ComplexLinearRegressionTests.cs
@@ -1,0 +1,72 @@
+using System;
+using System.Linq;
+using System.Numerics;
+using System.Text.Json;
+using NumFlat;
+using NumFlat.MultivariateAnalyses;
+using NumFlat.Serialization.Json;
+
+namespace SerializationJsonTest
+{
+    public class ComplexLinearRegressionTests
+    {
+        [Test]
+        public void RoundTripComplexLinearRegressionKeepsFittedParameters()
+        {
+            var options = NumFlatJsonSerializerOptions.Create();
+            var source = CreateComplexLinearRegression();
+
+            var json = JsonSerializer.Serialize(source, options);
+            var actual = JsonSerializer.Deserialize<ComplexLinearRegression>(json, options)!;
+
+            Assert.That(json, Is.EqualTo("{\"coefficients\":[[1,2],[3,4]],\"intercept\":[5,6]}"));
+            Assert.That(actual.Coefficients.ToArray(), Is.EqualTo(new[] { new Complex(1.0, 2.0), new Complex(3.0, 4.0) }));
+            Assert.That(actual.Intercept, Is.EqualTo(new Complex(5.0, 6.0)));
+        }
+
+        [Test]
+        public void RoundTripComplexLinearRegressionKeepsTransformBehavior()
+        {
+            var options = NumFlatJsonSerializerOptions.Create();
+            var source = CreateComplexLinearRegression();
+            var x = new Vec<Complex>(new[] { new Complex(7.0, 8.0), new Complex(9.0, 10.0) });
+            var expected = source.Transform(x);
+
+            var json = JsonSerializer.Serialize(source, options);
+            var actual = JsonSerializer.Deserialize<ComplexLinearRegression>(json, options)!;
+            var actualTransformed = actual.Transform(x);
+
+            Assert.That(actualTransformed.Real, Is.EqualTo(expected.Real).Within(1.0e-12));
+            Assert.That(actualTransformed.Imaginary, Is.EqualTo(expected.Imaginary).Within(1.0e-12));
+        }
+
+        [Test]
+        public void DeserializeComplexLinearRegressionHonorsCaseInsensitivePropertyNames()
+        {
+            var options = NumFlatJsonSerializerOptions.Create();
+            options.PropertyNameCaseInsensitive = true;
+            const string json = "{\"Coefficients\":[[1,2],[3,4]],\"Intercept\":[5,6]}";
+
+            var actual = JsonSerializer.Deserialize<ComplexLinearRegression>(json, options)!;
+
+            Assert.That(actual.Coefficients.ToArray(), Is.EqualTo(new[] { new Complex(1.0, 2.0), new Complex(3.0, 4.0) }));
+            Assert.That(actual.Intercept, Is.EqualTo(new Complex(5.0, 6.0)));
+        }
+
+        [Test]
+        public void DeserializeComplexLinearRegressionWithInvalidShapeThrowsJsonException()
+        {
+            var options = NumFlatJsonSerializerOptions.Create();
+            const string json = "{\"coefficients\":[],\"intercept\":[5,6]}";
+
+            Assert.That((Action)(() => JsonSerializer.Deserialize<ComplexLinearRegression>(json, options)), Throws.TypeOf<JsonException>());
+        }
+
+        private static ComplexLinearRegression CreateComplexLinearRegression()
+        {
+            var coefficients = new Vec<Complex>(new[] { new Complex(1.0, 2.0), new Complex(3.0, 4.0) });
+
+            return new ComplexLinearRegression(coefficients, new Complex(5.0, 6.0));
+        }
+    }
+}

--- a/SerializationJsonTest/LinearRegressionTests.cs
+++ b/SerializationJsonTest/LinearRegressionTests.cs
@@ -1,0 +1,70 @@
+using System;
+using System.Linq;
+using System.Text.Json;
+using NumFlat;
+using NumFlat.MultivariateAnalyses;
+using NumFlat.Serialization.Json;
+
+namespace SerializationJsonTest
+{
+    public class LinearRegressionTests
+    {
+        [Test]
+        public void RoundTripLinearRegressionKeepsFittedParameters()
+        {
+            var options = NumFlatJsonSerializerOptions.Create();
+            var source = CreateLinearRegression();
+
+            var json = JsonSerializer.Serialize(source, options);
+            var actual = JsonSerializer.Deserialize<LinearRegression>(json, options)!;
+
+            Assert.That(json, Is.EqualTo("{\"coefficients\":[1,2],\"intercept\":3}"));
+            Assert.That(actual.Coefficients.ToArray(), Is.EqualTo(new[] { 1.0, 2.0 }));
+            Assert.That(actual.Intercept, Is.EqualTo(3.0));
+        }
+
+        [Test]
+        public void RoundTripLinearRegressionKeepsTransformBehavior()
+        {
+            var options = NumFlatJsonSerializerOptions.Create();
+            var source = CreateLinearRegression();
+            var x = new Vec<double>(new[] { 5.0, 7.0 });
+            var expected = source.Transform(x);
+
+            var json = JsonSerializer.Serialize(source, options);
+            var actual = JsonSerializer.Deserialize<LinearRegression>(json, options)!;
+            var actualTransformed = actual.Transform(x);
+
+            Assert.That(actualTransformed, Is.EqualTo(expected).Within(1.0e-12));
+        }
+
+        [Test]
+        public void DeserializeLinearRegressionHonorsCaseInsensitivePropertyNames()
+        {
+            var options = NumFlatJsonSerializerOptions.Create();
+            options.PropertyNameCaseInsensitive = true;
+            const string json = "{\"Coefficients\":[1,2],\"Intercept\":3}";
+
+            var actual = JsonSerializer.Deserialize<LinearRegression>(json, options)!;
+
+            Assert.That(actual.Coefficients.ToArray(), Is.EqualTo(new[] { 1.0, 2.0 }));
+            Assert.That(actual.Intercept, Is.EqualTo(3.0));
+        }
+
+        [Test]
+        public void DeserializeLinearRegressionWithInvalidShapeThrowsJsonException()
+        {
+            var options = NumFlatJsonSerializerOptions.Create();
+            const string json = "{\"coefficients\":[],\"intercept\":3}";
+
+            Assert.That((Action)(() => JsonSerializer.Deserialize<LinearRegression>(json, options)), Throws.TypeOf<JsonException>());
+        }
+
+        private static LinearRegression CreateLinearRegression()
+        {
+            var coefficients = new Vec<double>(new[] { 1.0, 2.0 });
+
+            return new LinearRegression(coefficients, 3.0);
+        }
+    }
+}

--- a/SerializationJsonTest/LogisticRegressionTests.cs
+++ b/SerializationJsonTest/LogisticRegressionTests.cs
@@ -1,0 +1,73 @@
+using System;
+using System.Linq;
+using System.Text.Json;
+using NumFlat;
+using NumFlat.MultivariateAnalyses;
+using NumFlat.Serialization.Json;
+
+namespace SerializationJsonTest
+{
+    public class LogisticRegressionTests
+    {
+        [Test]
+        public void RoundTripLogisticRegressionKeepsFittedParameters()
+        {
+            var options = NumFlatJsonSerializerOptions.Create();
+            var source = CreateLogisticRegression();
+
+            var json = JsonSerializer.Serialize(source, options);
+            var actual = JsonSerializer.Deserialize<LogisticRegression>(json, options)!;
+
+            Assert.That(json, Is.EqualTo("{\"coefficients\":[1,2],\"intercept\":3}"));
+            Assert.That(actual.Coefficients.ToArray(), Is.EqualTo(new[] { 1.0, 2.0 }));
+            Assert.That(actual.Intercept, Is.EqualTo(3.0));
+        }
+
+        [Test]
+        public void RoundTripLogisticRegressionKeepsTransformAndPredictionBehavior()
+        {
+            var options = NumFlatJsonSerializerOptions.Create();
+            var source = CreateLogisticRegression();
+            var x = new Vec<double>(new[] { 5.0, 7.0 });
+            var expected = source.Transform(x);
+            var expectedPrediction = source.Predict(x);
+
+            var json = JsonSerializer.Serialize(source, options);
+            var actual = JsonSerializer.Deserialize<LogisticRegression>(json, options)!;
+            var actualTransformed = actual.Transform(x);
+            var actualPrediction = actual.Predict(x);
+
+            Assert.That(actualTransformed, Is.EqualTo(expected).Within(1.0e-12));
+            Assert.That(actualPrediction, Is.EqualTo(expectedPrediction));
+        }
+
+        [Test]
+        public void DeserializeLogisticRegressionHonorsCaseInsensitivePropertyNames()
+        {
+            var options = NumFlatJsonSerializerOptions.Create();
+            options.PropertyNameCaseInsensitive = true;
+            const string json = "{\"Coefficients\":[1,2],\"Intercept\":3}";
+
+            var actual = JsonSerializer.Deserialize<LogisticRegression>(json, options)!;
+
+            Assert.That(actual.Coefficients.ToArray(), Is.EqualTo(new[] { 1.0, 2.0 }));
+            Assert.That(actual.Intercept, Is.EqualTo(3.0));
+        }
+
+        [Test]
+        public void DeserializeLogisticRegressionWithInvalidShapeThrowsJsonException()
+        {
+            var options = NumFlatJsonSerializerOptions.Create();
+            const string json = "{\"coefficients\":[],\"intercept\":3}";
+
+            Assert.That((Action)(() => JsonSerializer.Deserialize<LogisticRegression>(json, options)), Throws.TypeOf<JsonException>());
+        }
+
+        private static LogisticRegression CreateLogisticRegression()
+        {
+            var coefficients = new Vec<double>(new[] { 1.0, 2.0 });
+
+            return new LogisticRegression(coefficients, 3.0);
+        }
+    }
+}


### PR DESCRIPTION
### Motivation
- Enable persisting and restoring fitted regression models by JSON by providing deserialization-aware constructors and converters for linear, logistic and complex linear regressions.
- Ensure serialized models preserve prediction behavior and validate input shape when deserialized.

### Description
- Added deserialization constructors to `LinearRegression`, `LogisticRegression` and `ComplexLinearRegression` that accept `coefficients` and `intercept` and validate the coefficient vector via `ThrowHelper.ThrowIfEmpty`.
- Implemented JSON converters `LinearRegressionJsonConverter`, `LogisticRegressionJsonConverter` and `ComplexLinearRegressionJsonConverter` that read and write the `coefficients` and `intercept` properties and construct model instances, throwing `JsonException` on missing or invalid properties.
- Registered the new converters in `NumFlatJsonSerializerOptionsExtensions.AddNumFlatConverters` so they are added by `NumFlatJsonSerializerOptions.Create()`.
- Added unit tests `LinearRegressionTests`, `LogisticRegressionTests` and `ComplexLinearRegressionTests` that verify round-trip serialization, preserved `Transform`/`Predict` behavior, case-insensitive property names, and that invalid shapes produce `JsonException`.

### Testing
- Ran unit tests `LinearRegressionTests`, `LogisticRegressionTests` and `ComplexLinearRegressionTests` which exercise serialization round-trips, behavior preservation, case-insensitive property names, and invalid-shape error paths.
- All added tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a06a41f7c348326932daaa8d3acb828)