### PR TITLE
Use verbatim JSON literals in serialization tests

### DIFF
--- a/SerializationJsonTest/ComplexLinearRegressionTests.cs
+++ b/SerializationJsonTest/ComplexLinearRegressionTests.cs
@@ -19,7 +19,7 @@ namespace SerializationJsonTest
             var json = JsonSerializer.Serialize(source, options);
             var actual = JsonSerializer.Deserialize<ComplexLinearRegression>(json, options)!;
 
-            Assert.That(json, Is.EqualTo("{\"coefficients\":[[1,2],[3,4]],\"intercept\":[5,6]}"));
+            Assert.That(json, Is.EqualTo(@"{""coefficients"":[[1,2],[3,4]],""intercept"":[5,6]}"));
             Assert.That(actual.Coefficients.ToArray(), Is.EqualTo(new[] { new Complex(1.0, 2.0), new Complex(3.0, 4.0) }));
             Assert.That(actual.Intercept, Is.EqualTo(new Complex(5.0, 6.0)));
         }
@@ -45,7 +45,7 @@ namespace SerializationJsonTest
         {
             var options = NumFlatJsonSerializerOptions.Create();
             options.PropertyNameCaseInsensitive = true;
-            const string json = "{\"Coefficients\":[[1,2],[3,4]],\"Intercept\":[5,6]}";
+            const string json = @"{""Coefficients"":[[1,2],[3,4]],""Intercept"":[5,6]}";
 
             var actual = JsonSerializer.Deserialize<ComplexLinearRegression>(json, options)!;
 
@@ -57,7 +57,7 @@ namespace SerializationJsonTest
         public void DeserializeComplexLinearRegressionWithInvalidShapeThrowsJsonException()
         {
             var options = NumFlatJsonSerializerOptions.Create();
-            const string json = "{\"coefficients\":[],\"intercept\":[5,6]}";
+            const string json = @"{""coefficients"":[],""intercept"":[5,6]}";
 
             Assert.That((Action)(() => JsonSerializer.Deserialize<ComplexLinearRegression>(json, options)), Throws.TypeOf<JsonException>());
         }

--- a/SerializationJsonTest/LinearDiscriminantAnalysisTests.cs
+++ b/SerializationJsonTest/LinearDiscriminantAnalysisTests.cs
@@ -18,7 +18,7 @@ namespace SerializationJsonTest
             var json = JsonSerializer.Serialize(source, options);
             var actual = JsonSerializer.Deserialize<LinearDiscriminantAnalysis>(json, options)!;
 
-            Assert.That(json, Is.EqualTo("{\"mean\":[1,2],\"eigenValues\":[3,4],\"eigenVectors\":[[0,1],[1,0]]}"));
+            Assert.That(json, Is.EqualTo(@"{""mean"":[1,2],""eigenValues"":[3,4],""eigenVectors"":[[0,1],[1,0]]}"));
             Assert.That(actual.Mean.ToArray(), Is.EqualTo(new[] { 1.0, 2.0 }));
             Assert.That(actual.EigenValues.ToArray(), Is.EqualTo(new[] { 3.0, 4.0 }));
             Assert.That(actual.EigenVectors[0, 0], Is.EqualTo(0.0));
@@ -47,7 +47,7 @@ namespace SerializationJsonTest
         {
             var options = NumFlatJsonSerializerOptions.Create();
             options.PropertyNameCaseInsensitive = true;
-            const string json = "{\"Mean\":[1,2],\"EigenValues\":[3,4],\"EigenVectors\":[[0,1],[1,0]]}";
+            const string json = @"{""Mean"":[1,2],""EigenValues"":[3,4],""EigenVectors"":[[0,1],[1,0]]}";
 
             var actual = JsonSerializer.Deserialize<LinearDiscriminantAnalysis>(json, options)!;
 
@@ -60,7 +60,7 @@ namespace SerializationJsonTest
         public void DeserializeLdaWithInvalidShapeThrowsJsonException()
         {
             var options = NumFlatJsonSerializerOptions.Create();
-            const string json = "{\"mean\":[1,2],\"eigenValues\":[3],\"eigenVectors\":[[1,0],[0,1]]}";
+            const string json = @"{""mean"":[1,2],""eigenValues"":[3],""eigenVectors"":[[1,0],[0,1]]}";
 
             Assert.That((Action)(() => JsonSerializer.Deserialize<LinearDiscriminantAnalysis>(json, options)), Throws.TypeOf<JsonException>());
         }

--- a/SerializationJsonTest/LinearRegressionTests.cs
+++ b/SerializationJsonTest/LinearRegressionTests.cs
@@ -18,7 +18,7 @@ namespace SerializationJsonTest
             var json = JsonSerializer.Serialize(source, options);
             var actual = JsonSerializer.Deserialize<LinearRegression>(json, options)!;
 
-            Assert.That(json, Is.EqualTo("{\"coefficients\":[1,2],\"intercept\":3}"));
+            Assert.That(json, Is.EqualTo(@"{""coefficients"":[1,2],""intercept"":3}"));
             Assert.That(actual.Coefficients.ToArray(), Is.EqualTo(new[] { 1.0, 2.0 }));
             Assert.That(actual.Intercept, Is.EqualTo(3.0));
         }
@@ -43,7 +43,7 @@ namespace SerializationJsonTest
         {
             var options = NumFlatJsonSerializerOptions.Create();
             options.PropertyNameCaseInsensitive = true;
-            const string json = "{\"Coefficients\":[1,2],\"Intercept\":3}";
+            const string json = @"{""Coefficients"":[1,2],""Intercept"":3}";
 
             var actual = JsonSerializer.Deserialize<LinearRegression>(json, options)!;
 
@@ -55,7 +55,7 @@ namespace SerializationJsonTest
         public void DeserializeLinearRegressionWithInvalidShapeThrowsJsonException()
         {
             var options = NumFlatJsonSerializerOptions.Create();
-            const string json = "{\"coefficients\":[],\"intercept\":3}";
+            const string json = @"{""coefficients"":[],""intercept"":3}";
 
             Assert.That((Action)(() => JsonSerializer.Deserialize<LinearRegression>(json, options)), Throws.TypeOf<JsonException>());
         }

--- a/SerializationJsonTest/LogisticRegressionTests.cs
+++ b/SerializationJsonTest/LogisticRegressionTests.cs
@@ -18,7 +18,7 @@ namespace SerializationJsonTest
             var json = JsonSerializer.Serialize(source, options);
             var actual = JsonSerializer.Deserialize<LogisticRegression>(json, options)!;
 
-            Assert.That(json, Is.EqualTo("{\"coefficients\":[1,2],\"intercept\":3}"));
+            Assert.That(json, Is.EqualTo(@"{""coefficients"":[1,2],""intercept"":3}"));
             Assert.That(actual.Coefficients.ToArray(), Is.EqualTo(new[] { 1.0, 2.0 }));
             Assert.That(actual.Intercept, Is.EqualTo(3.0));
         }
@@ -46,7 +46,7 @@ namespace SerializationJsonTest
         {
             var options = NumFlatJsonSerializerOptions.Create();
             options.PropertyNameCaseInsensitive = true;
-            const string json = "{\"Coefficients\":[1,2],\"Intercept\":3}";
+            const string json = @"{""Coefficients"":[1,2],""Intercept"":3}";
 
             var actual = JsonSerializer.Deserialize<LogisticRegression>(json, options)!;
 
@@ -58,7 +58,7 @@ namespace SerializationJsonTest
         public void DeserializeLogisticRegressionWithInvalidShapeThrowsJsonException()
         {
             var options = NumFlatJsonSerializerOptions.Create();
-            const string json = "{\"coefficients\":[],\"intercept\":3}";
+            const string json = @"{""coefficients"":[],""intercept"":3}";
 
             Assert.That((Action)(() => JsonSerializer.Deserialize<LogisticRegression>(json, options)), Throws.TypeOf<JsonException>());
         }

--- a/SerializationJsonTest/PrincipalComponentAnalysisTests.cs
+++ b/SerializationJsonTest/PrincipalComponentAnalysisTests.cs
@@ -18,7 +18,7 @@ namespace SerializationJsonTest
             var json = JsonSerializer.Serialize(source, options);
             var actual = JsonSerializer.Deserialize<PrincipalComponentAnalysis>(json, options)!;
 
-            Assert.That(json, Is.EqualTo("{\"mean\":[1,2],\"eigenValues\":[3,4],\"eigenVectors\":[[0,1],[1,0]]}"));
+            Assert.That(json, Is.EqualTo(@"{""mean"":[1,2],""eigenValues"":[3,4],""eigenVectors"":[[0,1],[1,0]]}"));
             Assert.That(actual.Mean.ToArray(), Is.EqualTo(new[] { 1.0, 2.0 }));
             Assert.That(actual.EigenValues.ToArray(), Is.EqualTo(new[] { 3.0, 4.0 }));
             Assert.That(actual.EigenVectors[0, 0], Is.EqualTo(0.0));
@@ -48,7 +48,7 @@ namespace SerializationJsonTest
         public void DeserializePcaWithInvalidShapeThrowsJsonException()
         {
             var options = NumFlatJsonSerializerOptions.Create();
-            const string json = "{\"mean\":[1,2],\"eigenValues\":[3],\"eigenVectors\":[[1,0],[0,1]]}";
+            const string json = @"{""mean"":[1,2],""eigenValues"":[3],""eigenVectors"":[[1,0],[0,1]]}";
 
             Assert.That((Action)(() => JsonSerializer.Deserialize<PrincipalComponentAnalysis>(json, options)), Throws.TypeOf<JsonException>());
         }


### PR DESCRIPTION
### Motivation
- Improve readability of JSON literals in tests by avoiding heavy escaping in C# string literals.

### Description
- Converted JSON expectations and input strings in serialization tests to verbatim string literals using `@"..."` with doubled quotes for internal quotes.
- Updated the following test files: `SerializationJsonTest/LinearRegressionTests.cs`, `SerializationJsonTest/LogisticRegressionTests.cs`, `SerializationJsonTest/ComplexLinearRegressionTests.cs`, `SerializationJsonTest/LinearDiscriminantAnalysisTests.cs`, and `SerializationJsonTest/PrincipalComponentAnalysisTests.cs`.
- Changes only affect test source formattings and do not alter runtime logic or serialization behavior.

### Testing
- Ran `dotnet test SerializationJsonTest/SerializationJsonTest.csproj` and all tests passed successfully.
- Test summary: `Passed: 33, Failed: 0, Skipped: 0` (duration reported by runner).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a06ab85bf848326a75e2b49e3ff6f62)