### PR TITLE
Add JSON serialization support for CSP, ICA and NMF with deserialization constructors and tests

### DIFF
--- a/NumFlat/MultivariateAnalyses/CommonSpatialPattern.cs
+++ b/NumFlat/MultivariateAnalyses/CommonSpatialPattern.cs
@@ -9,7 +9,8 @@ namespace NumFlat.MultivariateAnalyses
     /// </summary>
     public sealed class CommonSpatialPattern : IVectorToVectorTransform<double>
     {
-        private readonly GeneralizedEigenValueDecompositionDouble gevd;
+        private readonly Vec<double> eigenValues;
+        private readonly Mat<double> eigenVectors;
 
         /// <summary>
         /// Performs common spatial pattern (CSP).
@@ -97,7 +98,35 @@ namespace NumFlat.MultivariateAnalyses
                 throw new FittingFailureException("Failed to compute the GEVD of the covariance matrices.", e);
             }
 
-            this.gevd = gevd;
+            this.eigenValues = gevd.D;
+            this.eigenVectors = gevd.V;
+        }
+
+        /// <summary>
+        /// Creates common spatial pattern (CSP) from fitted parameters.
+        /// </summary>
+        /// <param name="eigenValues">
+        /// The eigenvalues obtained from the generalized eigenvalue decomposition.
+        /// </param>
+        /// <param name="eigenVectors">
+        /// The eigenvectors obtained from the generalized eigenvalue decomposition.
+        /// </param>
+        /// <remarks>
+        /// This constructor is intended primarily for deserializers that reconstruct a fitted model from persisted parameters.
+        /// The given vector and matrix are stored directly, so they should not be mutated after construction.
+        /// </remarks>
+        public CommonSpatialPattern(in Vec<double> eigenValues, in Mat<double> eigenVectors)
+        {
+            ThrowHelper.ThrowIfEmpty(eigenValues, nameof(eigenValues));
+            ThrowHelper.ThrowIfEmpty(eigenVectors, nameof(eigenVectors));
+
+            if (eigenVectors.RowCount != eigenValues.Count || eigenVectors.ColCount != eigenValues.Count)
+            {
+                throw new ArgumentException($"The eigenvector matrix must be {eigenValues.Count} x {eigenValues.Count}, but was {eigenVectors.RowCount} x {eigenVectors.ColCount}.", nameof(eigenVectors));
+            }
+
+            this.eigenValues = eigenValues;
+            this.eigenVectors = eigenVectors;
         }
 
         /// <inheritdoc/>
@@ -107,23 +136,23 @@ namespace NumFlat.MultivariateAnalyses
             ThrowHelper.ThrowIfEmpty(destination, nameof(destination));
             VectorToVectorTransform.ThrowIfInvalidSize(this, source, destination, nameof(source), nameof(destination));
 
-            Mat.Mul(gevd.V, source, destination, true);
+            Mat.Mul(eigenVectors, source, destination, true);
         }
 
         /// <summary>
         /// Gets the eigenvalues obtained from the generalized eigenvalue decomposition.
         /// </summary>
-        public ref readonly Vec<double> EigenValues => ref gevd.D;
+        public ref readonly Vec<double> EigenValues => ref eigenValues;
 
         /// <summary>
         /// Gets the eigenvectors obtained from the generalized eigenvalue decomposition.
         /// </summary>
-        public ref readonly Mat<double> EigenVectors => ref gevd.V;
+        public ref readonly Mat<double> EigenVectors => ref eigenVectors;
 
         /// <inheritdoc/>
-        public int SourceDimension => gevd.D.Count;
+        public int SourceDimension => eigenValues.Count;
 
         /// <inheritdoc/>
-        public int DestinationDimension => gevd.D.Count;
+        public int DestinationDimension => eigenValues.Count;
     }
 }

--- a/NumFlat/MultivariateAnalyses/IndependentComponentAnalysis.cs
+++ b/NumFlat/MultivariateAnalyses/IndependentComponentAnalysis.cs
@@ -168,6 +168,45 @@ namespace NumFlat.MultivariateAnalyses
             this.mixingMatrix = demixingMatrix.PseudoInverse();
         }
 
+        /// <summary>
+        /// Creates independent component analysis (ICA) from fitted parameters.
+        /// </summary>
+        /// <param name="mean">
+        /// The mean vector of the source vectors.
+        /// </param>
+        /// <param name="demixingMatrix">
+        /// The demixing matrix.
+        /// </param>
+        /// <param name="mixingMatrix">
+        /// The mixing matrix.
+        /// </param>
+        /// <remarks>
+        /// This constructor is intended primarily for deserializers that reconstruct a fitted model from persisted parameters.
+        /// The given vector and matrices are stored directly, so they should not be mutated after construction.
+        /// </remarks>
+        public IndependentComponentAnalysis(in Vec<double> mean, in Mat<double> demixingMatrix, in Mat<double> mixingMatrix)
+        {
+            ThrowHelper.ThrowIfEmpty(mean, nameof(mean));
+            ThrowHelper.ThrowIfEmpty(demixingMatrix, nameof(demixingMatrix));
+            ThrowHelper.ThrowIfEmpty(mixingMatrix, nameof(mixingMatrix));
+
+            if (demixingMatrix.ColCount != mean.Count)
+            {
+                throw new ArgumentException($"The column count of the demixing matrix must be {mean.Count}, but was {demixingMatrix.ColCount}.", nameof(demixingMatrix));
+            }
+
+            if (mixingMatrix.RowCount != mean.Count || mixingMatrix.ColCount != demixingMatrix.RowCount)
+            {
+                throw new ArgumentException($"The mixing matrix must be {mean.Count} x {demixingMatrix.RowCount}, but was {mixingMatrix.RowCount} x {mixingMatrix.ColCount}.", nameof(mixingMatrix));
+            }
+
+            this.sourceDimension = mean.Count;
+            this.componentCount = demixingMatrix.RowCount;
+            this.mean = mean;
+            this.demixingMatrix = demixingMatrix;
+            this.mixingMatrix = mixingMatrix;
+        }
+
         /// <inheritdoc/>
         public void Transform(in Vec<double> source, in Vec<double> destination)
         {

--- a/NumFlat/MultivariateAnalyses/NonnegativeMatrixFactorization.cs
+++ b/NumFlat/MultivariateAnalyses/NonnegativeMatrixFactorization.cs
@@ -77,6 +77,33 @@ namespace NumFlat.MultivariateAnalyses
         }
 
         /// <summary>
+        /// Creates non-negative matrix factorization (NMF) from fitted parameters.
+        /// </summary>
+        /// <param name="w">
+        /// The basis vectors.
+        /// </param>
+        /// <param name="h">
+        /// The activation vectors.
+        /// </param>
+        /// <remarks>
+        /// This constructor is intended primarily for deserializers that reconstruct a fitted model from persisted parameters.
+        /// The given matrices are stored directly, so they should not be mutated after construction.
+        /// </remarks>
+        public NonnegativeMatrixFactorization(in Mat<double> w, in Mat<double> h)
+        {
+            ThrowHelper.ThrowIfEmpty(w, nameof(w));
+            ThrowHelper.ThrowIfEmpty(h, nameof(h));
+
+            if (w.ColCount != h.RowCount)
+            {
+                throw new ArgumentException($"The column count of W must match the row count of H, but they were {w.ColCount} and {h.RowCount}.");
+            }
+
+            this.w = w;
+            this.h = h;
+        }
+
+        /// <summary>
         /// Generates initial values for the matrices W and H using a random number generator.
         /// </summary>
         /// <param name="xs">

--- a/SerializationJson/CommonSpatialPatternJsonConverter.cs
+++ b/SerializationJson/CommonSpatialPatternJsonConverter.cs
@@ -1,0 +1,95 @@
+﻿using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using NumFlat.MultivariateAnalyses;
+
+namespace NumFlat.Serialization.Json
+{
+    /// <summary>
+    /// Converts <see cref="CommonSpatialPattern" /> instances to and from JSON.
+    /// </summary>
+    public sealed class CommonSpatialPatternJsonConverter : JsonConverter<CommonSpatialPattern>
+    {
+        private const string EigenValuesPropertyName = "eigenValues";
+        private const string EigenVectorsPropertyName = "eigenVectors";
+
+        /// <inheritdoc />
+        public override CommonSpatialPattern Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            if (reader.TokenType != JsonTokenType.StartObject)
+            {
+                throw new JsonException("A NumFlat CSP object must be represented as a JSON object.");
+            }
+
+            Vec<double>? eigenValues = null;
+            Mat<double>? eigenVectors = null;
+
+            while (reader.Read())
+            {
+                if (reader.TokenType == JsonTokenType.EndObject)
+                {
+                    return CreateCsp(eigenValues, eigenVectors);
+                }
+
+                if (reader.TokenType != JsonTokenType.PropertyName)
+                {
+                    throw new JsonException("A NumFlat CSP object property name is expected.");
+                }
+
+                var propertyName = reader.GetString();
+                if (!reader.Read())
+                {
+                    throw new JsonException("The JSON object for a NumFlat CSP object is incomplete.");
+                }
+
+                if (JsonSerializationHelpers.PropertyNameEquals(propertyName, EigenValuesPropertyName, options))
+                {
+                    eigenValues = JsonSerializer.Deserialize<Vec<double>>(ref reader, options);
+                }
+                else if (JsonSerializationHelpers.PropertyNameEquals(propertyName, EigenVectorsPropertyName, options))
+                {
+                    eigenVectors = JsonSerializer.Deserialize<Mat<double>>(ref reader, options);
+                }
+                else
+                {
+                    reader.Skip();
+                }
+            }
+
+            throw new JsonException("The JSON object for a NumFlat CSP object is incomplete.");
+        }
+
+        /// <inheritdoc />
+        public override void Write(Utf8JsonWriter writer, CommonSpatialPattern value, JsonSerializerOptions options)
+        {
+            writer.WriteStartObject();
+            writer.WritePropertyName(EigenValuesPropertyName);
+            JsonSerializer.Serialize(writer, value.EigenValues, options);
+            writer.WritePropertyName(EigenVectorsPropertyName);
+            JsonSerializer.Serialize(writer, value.EigenVectors, options);
+            writer.WriteEndObject();
+        }
+
+        private static CommonSpatialPattern CreateCsp(Vec<double>? eigenValues, Mat<double>? eigenVectors)
+        {
+            if (eigenValues == null)
+            {
+                throw new JsonException("The JSON object for a NumFlat CSP object must contain an 'eigenValues' property.");
+            }
+
+            if (eigenVectors == null)
+            {
+                throw new JsonException("The JSON object for a NumFlat CSP object must contain an 'eigenVectors' property.");
+            }
+
+            try
+            {
+                return new CommonSpatialPattern(eigenValues.Value, eigenVectors.Value);
+            }
+            catch (ArgumentException ex)
+            {
+                throw new JsonException("The JSON object cannot be converted to a NumFlat CSP object.", ex);
+            }
+        }
+    }
+}

--- a/SerializationJson/IndependentComponentAnalysisJsonConverter.cs
+++ b/SerializationJson/IndependentComponentAnalysisJsonConverter.cs
@@ -1,0 +1,108 @@
+﻿using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using NumFlat.MultivariateAnalyses;
+
+namespace NumFlat.Serialization.Json
+{
+    /// <summary>
+    /// Converts <see cref="IndependentComponentAnalysis" /> instances to and from JSON.
+    /// </summary>
+    public sealed class IndependentComponentAnalysisJsonConverter : JsonConverter<IndependentComponentAnalysis>
+    {
+        private const string MeanPropertyName = "mean";
+        private const string DemixingMatrixPropertyName = "demixingMatrix";
+        private const string MixingMatrixPropertyName = "mixingMatrix";
+
+        /// <inheritdoc />
+        public override IndependentComponentAnalysis Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            if (reader.TokenType != JsonTokenType.StartObject)
+            {
+                throw new JsonException("A NumFlat ICA object must be represented as a JSON object.");
+            }
+
+            Vec<double>? mean = null;
+            Mat<double>? demixingMatrix = null;
+            Mat<double>? mixingMatrix = null;
+
+            while (reader.Read())
+            {
+                if (reader.TokenType == JsonTokenType.EndObject)
+                {
+                    return CreateIca(mean, demixingMatrix, mixingMatrix);
+                }
+
+                if (reader.TokenType != JsonTokenType.PropertyName)
+                {
+                    throw new JsonException("A NumFlat ICA object property name is expected.");
+                }
+
+                var propertyName = reader.GetString();
+                if (!reader.Read())
+                {
+                    throw new JsonException("The JSON object for a NumFlat ICA object is incomplete.");
+                }
+
+                if (JsonSerializationHelpers.PropertyNameEquals(propertyName, MeanPropertyName, options))
+                {
+                    mean = JsonSerializer.Deserialize<Vec<double>>(ref reader, options);
+                }
+                else if (JsonSerializationHelpers.PropertyNameEquals(propertyName, DemixingMatrixPropertyName, options))
+                {
+                    demixingMatrix = JsonSerializer.Deserialize<Mat<double>>(ref reader, options);
+                }
+                else if (JsonSerializationHelpers.PropertyNameEquals(propertyName, MixingMatrixPropertyName, options))
+                {
+                    mixingMatrix = JsonSerializer.Deserialize<Mat<double>>(ref reader, options);
+                }
+                else
+                {
+                    reader.Skip();
+                }
+            }
+
+            throw new JsonException("The JSON object for a NumFlat ICA object is incomplete.");
+        }
+
+        /// <inheritdoc />
+        public override void Write(Utf8JsonWriter writer, IndependentComponentAnalysis value, JsonSerializerOptions options)
+        {
+            writer.WriteStartObject();
+            writer.WritePropertyName(MeanPropertyName);
+            JsonSerializer.Serialize(writer, value.Mean, options);
+            writer.WritePropertyName(DemixingMatrixPropertyName);
+            JsonSerializer.Serialize(writer, value.DemixingMatrix, options);
+            writer.WritePropertyName(MixingMatrixPropertyName);
+            JsonSerializer.Serialize(writer, value.MixingMatrix, options);
+            writer.WriteEndObject();
+        }
+
+        private static IndependentComponentAnalysis CreateIca(Vec<double>? mean, Mat<double>? demixingMatrix, Mat<double>? mixingMatrix)
+        {
+            if (mean == null)
+            {
+                throw new JsonException("The JSON object for a NumFlat ICA object must contain a 'mean' property.");
+            }
+
+            if (demixingMatrix == null)
+            {
+                throw new JsonException("The JSON object for a NumFlat ICA object must contain a 'demixingMatrix' property.");
+            }
+
+            if (mixingMatrix == null)
+            {
+                throw new JsonException("The JSON object for a NumFlat ICA object must contain a 'mixingMatrix' property.");
+            }
+
+            try
+            {
+                return new IndependentComponentAnalysis(mean.Value, demixingMatrix.Value, mixingMatrix.Value);
+            }
+            catch (ArgumentException ex)
+            {
+                throw new JsonException("The JSON object cannot be converted to a NumFlat ICA object.", ex);
+            }
+        }
+    }
+}

--- a/SerializationJson/NonnegativeMatrixFactorizationJsonConverter.cs
+++ b/SerializationJson/NonnegativeMatrixFactorizationJsonConverter.cs
@@ -1,0 +1,95 @@
+﻿using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using NumFlat.MultivariateAnalyses;
+
+namespace NumFlat.Serialization.Json
+{
+    /// <summary>
+    /// Converts <see cref="NonnegativeMatrixFactorization" /> instances to and from JSON.
+    /// </summary>
+    public sealed class NonnegativeMatrixFactorizationJsonConverter : JsonConverter<NonnegativeMatrixFactorization>
+    {
+        private const string WPropertyName = "w";
+        private const string HPropertyName = "h";
+
+        /// <inheritdoc />
+        public override NonnegativeMatrixFactorization Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            if (reader.TokenType != JsonTokenType.StartObject)
+            {
+                throw new JsonException("A NumFlat NMF object must be represented as a JSON object.");
+            }
+
+            Mat<double>? w = null;
+            Mat<double>? h = null;
+
+            while (reader.Read())
+            {
+                if (reader.TokenType == JsonTokenType.EndObject)
+                {
+                    return CreateNmf(w, h);
+                }
+
+                if (reader.TokenType != JsonTokenType.PropertyName)
+                {
+                    throw new JsonException("A NumFlat NMF object property name is expected.");
+                }
+
+                var propertyName = reader.GetString();
+                if (!reader.Read())
+                {
+                    throw new JsonException("The JSON object for a NumFlat NMF object is incomplete.");
+                }
+
+                if (JsonSerializationHelpers.PropertyNameEquals(propertyName, WPropertyName, options))
+                {
+                    w = JsonSerializer.Deserialize<Mat<double>>(ref reader, options);
+                }
+                else if (JsonSerializationHelpers.PropertyNameEquals(propertyName, HPropertyName, options))
+                {
+                    h = JsonSerializer.Deserialize<Mat<double>>(ref reader, options);
+                }
+                else
+                {
+                    reader.Skip();
+                }
+            }
+
+            throw new JsonException("The JSON object for a NumFlat NMF object is incomplete.");
+        }
+
+        /// <inheritdoc />
+        public override void Write(Utf8JsonWriter writer, NonnegativeMatrixFactorization value, JsonSerializerOptions options)
+        {
+            writer.WriteStartObject();
+            writer.WritePropertyName(WPropertyName);
+            JsonSerializer.Serialize(writer, value.W, options);
+            writer.WritePropertyName(HPropertyName);
+            JsonSerializer.Serialize(writer, value.H, options);
+            writer.WriteEndObject();
+        }
+
+        private static NonnegativeMatrixFactorization CreateNmf(Mat<double>? w, Mat<double>? h)
+        {
+            if (w == null)
+            {
+                throw new JsonException("The JSON object for a NumFlat NMF object must contain a 'w' property.");
+            }
+
+            if (h == null)
+            {
+                throw new JsonException("The JSON object for a NumFlat NMF object must contain an 'h' property.");
+            }
+
+            try
+            {
+                return new NonnegativeMatrixFactorization(w.Value, h.Value);
+            }
+            catch (ArgumentException ex)
+            {
+                throw new JsonException("The JSON object cannot be converted to a NumFlat NMF object.", ex);
+            }
+        }
+    }
+}

--- a/SerializationJson/NumFlatJsonSerializerOptionsExtensions.cs
+++ b/SerializationJson/NumFlatJsonSerializerOptionsExtensions.cs
@@ -29,6 +29,9 @@ namespace NumFlat.Serialization.Json
             JsonSerializationHelpers.AddConverterIfMissing<MatJsonConverterFactory>(options);
             JsonSerializationHelpers.AddConverterIfMissing<PrincipalComponentAnalysisJsonConverter>(options);
             JsonSerializationHelpers.AddConverterIfMissing<LinearDiscriminantAnalysisJsonConverter>(options);
+            JsonSerializationHelpers.AddConverterIfMissing<CommonSpatialPatternJsonConverter>(options);
+            JsonSerializationHelpers.AddConverterIfMissing<IndependentComponentAnalysisJsonConverter>(options);
+            JsonSerializationHelpers.AddConverterIfMissing<NonnegativeMatrixFactorizationJsonConverter>(options);
             JsonSerializationHelpers.AddConverterIfMissing<LinearRegressionJsonConverter>(options);
             JsonSerializationHelpers.AddConverterIfMissing<ComplexLinearRegressionJsonConverter>(options);
             JsonSerializationHelpers.AddConverterIfMissing<LogisticRegressionJsonConverter>(options);

--- a/SerializationJsonTest/CommonSpatialPatternTests.cs
+++ b/SerializationJsonTest/CommonSpatialPatternTests.cs
@@ -1,0 +1,78 @@
+using System;
+using System.Linq;
+using System.Text.Json;
+using NumFlat;
+using NumFlat.MultivariateAnalyses;
+using NumFlat.Serialization.Json;
+
+namespace SerializationJsonTest
+{
+    public class CommonSpatialPatternTests
+    {
+        [Test]
+        public void RoundTripCspKeepsFittedParameters()
+        {
+            var options = NumFlatJsonSerializerOptions.Create();
+            var source = CreateCsp();
+
+            var json = JsonSerializer.Serialize(source, options);
+            var actual = JsonSerializer.Deserialize<CommonSpatialPattern>(json, options)!;
+
+            Assert.That(json, Is.EqualTo(@"{""eigenValues"":[3,4],""eigenVectors"":[[0,1],[1,0]]}"));
+            Assert.That(actual.EigenValues.ToArray(), Is.EqualTo(new[] { 3.0, 4.0 }));
+            Assert.That(actual.EigenVectors[0, 0], Is.EqualTo(0.0));
+            Assert.That(actual.EigenVectors[0, 1], Is.EqualTo(1.0));
+            Assert.That(actual.EigenVectors[1, 0], Is.EqualTo(1.0));
+            Assert.That(actual.EigenVectors[1, 1], Is.EqualTo(0.0));
+        }
+
+        [Test]
+        public void RoundTripCspKeepsTransformBehavior()
+        {
+            var options = NumFlatJsonSerializerOptions.Create();
+            var source = CreateCsp();
+            var x = new Vec<double>(new[] { 5.0, 7.0 });
+            var expected = source.Transform(x);
+
+            var json = JsonSerializer.Serialize(source, options);
+            var actual = JsonSerializer.Deserialize<CommonSpatialPattern>(json, options)!;
+            var actualTransformed = actual.Transform(x);
+
+            Assert.That(actualTransformed.ToArray(), Is.EqualTo(expected.ToArray()).Within(1.0e-12));
+        }
+
+        [Test]
+        public void DeserializeCspHonorsCaseInsensitivePropertyNames()
+        {
+            var options = NumFlatJsonSerializerOptions.Create();
+            options.PropertyNameCaseInsensitive = true;
+            const string json = @"{""EigenValues"":[3,4],""EigenVectors"":[[0,1],[1,0]]}";
+
+            var actual = JsonSerializer.Deserialize<CommonSpatialPattern>(json, options)!;
+
+            Assert.That(actual.EigenValues.ToArray(), Is.EqualTo(new[] { 3.0, 4.0 }));
+            Assert.That(actual.EigenVectors[0, 1], Is.EqualTo(1.0));
+        }
+
+        [Test]
+        public void DeserializeCspWithInvalidShapeThrowsJsonException()
+        {
+            var options = NumFlatJsonSerializerOptions.Create();
+            const string json = @"{""eigenValues"":[3],""eigenVectors"":[[1,0],[0,1]]}";
+
+            Assert.That((Action)(() => JsonSerializer.Deserialize<CommonSpatialPattern>(json, options)), Throws.TypeOf<JsonException>());
+        }
+
+        private static CommonSpatialPattern CreateCsp()
+        {
+            var eigenValues = new Vec<double>(new[] { 3.0, 4.0 });
+            var eigenVectors = new Mat<double>(2, 2, 2, new[]
+            {
+                0.0, 1.0,
+                1.0, 0.0
+            });
+
+            return new CommonSpatialPattern(eigenValues, eigenVectors);
+        }
+    }
+}

--- a/SerializationJsonTest/IndependentComponentAnalysisTests.cs
+++ b/SerializationJsonTest/IndependentComponentAnalysisTests.cs
@@ -1,0 +1,97 @@
+using System;
+using System.Linq;
+using System.Text.Json;
+using NumFlat;
+using NumFlat.MultivariateAnalyses;
+using NumFlat.Serialization.Json;
+
+namespace SerializationJsonTest
+{
+    public class IndependentComponentAnalysisTests
+    {
+        [Test]
+        public void RoundTripIcaKeepsFittedParameters()
+        {
+            var options = NumFlatJsonSerializerOptions.Create();
+            var source = CreateIca();
+
+            var json = JsonSerializer.Serialize(source, options);
+            var actual = JsonSerializer.Deserialize<IndependentComponentAnalysis>(json, options)!;
+
+            Assert.That(json, Is.EqualTo(@"{""mean"":[1,2,3],""demixingMatrix"":[[1,2,3],[4,5,6]],""mixingMatrix"":[[7,8],[9,10],[11,12]]}"));
+            Assert.That(actual.Mean.ToArray(), Is.EqualTo(new[] { 1.0, 2.0, 3.0 }));
+            Assert.That(actual.DemixingMatrix[0, 0], Is.EqualTo(1.0));
+            Assert.That(actual.DemixingMatrix[0, 1], Is.EqualTo(2.0));
+            Assert.That(actual.DemixingMatrix[0, 2], Is.EqualTo(3.0));
+            Assert.That(actual.DemixingMatrix[1, 0], Is.EqualTo(4.0));
+            Assert.That(actual.DemixingMatrix[1, 1], Is.EqualTo(5.0));
+            Assert.That(actual.DemixingMatrix[1, 2], Is.EqualTo(6.0));
+            Assert.That(actual.MixingMatrix[0, 0], Is.EqualTo(7.0));
+            Assert.That(actual.MixingMatrix[0, 1], Is.EqualTo(8.0));
+            Assert.That(actual.MixingMatrix[1, 0], Is.EqualTo(9.0));
+            Assert.That(actual.MixingMatrix[1, 1], Is.EqualTo(10.0));
+            Assert.That(actual.MixingMatrix[2, 0], Is.EqualTo(11.0));
+            Assert.That(actual.MixingMatrix[2, 1], Is.EqualTo(12.0));
+        }
+
+        [Test]
+        public void RoundTripIcaKeepsTransformBehavior()
+        {
+            var options = NumFlatJsonSerializerOptions.Create();
+            var source = CreateIca();
+            var x = new Vec<double>(new[] { 5.0, 7.0, 11.0 });
+            var y = new Vec<double>(new[] { 13.0, 17.0 });
+            var expectedTransformed = source.Transform(x);
+            var expectedRestored = source.InverseTransform(y);
+
+            var json = JsonSerializer.Serialize(source, options);
+            var actual = JsonSerializer.Deserialize<IndependentComponentAnalysis>(json, options)!;
+            var actualTransformed = actual.Transform(x);
+            var actualRestored = actual.InverseTransform(y);
+
+            Assert.That(actualTransformed.ToArray(), Is.EqualTo(expectedTransformed.ToArray()).Within(1.0e-12));
+            Assert.That(actualRestored.ToArray(), Is.EqualTo(expectedRestored.ToArray()).Within(1.0e-12));
+        }
+
+        [Test]
+        public void DeserializeIcaHonorsCaseInsensitivePropertyNames()
+        {
+            var options = NumFlatJsonSerializerOptions.Create();
+            options.PropertyNameCaseInsensitive = true;
+            const string json = @"{""Mean"":[1,2,3],""DemixingMatrix"":[[1,2,3],[4,5,6]],""MixingMatrix"":[[7,8],[9,10],[11,12]]}";
+
+            var actual = JsonSerializer.Deserialize<IndependentComponentAnalysis>(json, options)!;
+
+            Assert.That(actual.Mean.ToArray(), Is.EqualTo(new[] { 1.0, 2.0, 3.0 }));
+            Assert.That(actual.DemixingMatrix[1, 2], Is.EqualTo(6.0));
+            Assert.That(actual.MixingMatrix[2, 1], Is.EqualTo(12.0));
+        }
+
+        [Test]
+        public void DeserializeIcaWithInvalidShapeThrowsJsonException()
+        {
+            var options = NumFlatJsonSerializerOptions.Create();
+            const string json = @"{""mean"":[1,2,3],""demixingMatrix"":[[1,2],[3,4]],""mixingMatrix"":[[5,6],[7,8],[9,10]]}";
+
+            Assert.That((Action)(() => JsonSerializer.Deserialize<IndependentComponentAnalysis>(json, options)), Throws.TypeOf<JsonException>());
+        }
+
+        private static IndependentComponentAnalysis CreateIca()
+        {
+            var mean = new Vec<double>(new[] { 1.0, 2.0, 3.0 });
+            Mat<double> demixingMatrix =
+            [
+                [1.0, 2.0, 3.0],
+                [4.0, 5.0, 6.0],
+            ];
+            Mat<double> mixingMatrix =
+            [
+                [7.0, 8.0],
+                [9.0, 10.0],
+                [11.0, 12.0],
+            ];
+
+            return new IndependentComponentAnalysis(mean, demixingMatrix, mixingMatrix);
+        }
+    }
+}

--- a/SerializationJsonTest/NonnegativeMatrixFactorizationTests.cs
+++ b/SerializationJsonTest/NonnegativeMatrixFactorizationTests.cs
@@ -1,0 +1,96 @@
+using System;
+using System.Text.Json;
+using NumFlat;
+using NumFlat.MultivariateAnalyses;
+using NumFlat.Serialization.Json;
+
+namespace SerializationJsonTest
+{
+    public class NonnegativeMatrixFactorizationTests
+    {
+        [Test]
+        public void RoundTripNmfKeepsFittedParameters()
+        {
+            var options = NumFlatJsonSerializerOptions.Create();
+            var source = CreateNmf();
+
+            var json = JsonSerializer.Serialize(source, options);
+            var actual = JsonSerializer.Deserialize<NonnegativeMatrixFactorization>(json, options)!;
+
+            Assert.That(json, Is.EqualTo(@"{""w"":[[1,2],[3,4],[5,6]],""h"":[[7,8,9],[10,11,12]]}"));
+            Assert.That(actual.W[0, 0], Is.EqualTo(1.0));
+            Assert.That(actual.W[0, 1], Is.EqualTo(2.0));
+            Assert.That(actual.W[1, 0], Is.EqualTo(3.0));
+            Assert.That(actual.W[1, 1], Is.EqualTo(4.0));
+            Assert.That(actual.W[2, 0], Is.EqualTo(5.0));
+            Assert.That(actual.W[2, 1], Is.EqualTo(6.0));
+            Assert.That(actual.H[0, 0], Is.EqualTo(7.0));
+            Assert.That(actual.H[0, 1], Is.EqualTo(8.0));
+            Assert.That(actual.H[0, 2], Is.EqualTo(9.0));
+            Assert.That(actual.H[1, 0], Is.EqualTo(10.0));
+            Assert.That(actual.H[1, 1], Is.EqualTo(11.0));
+            Assert.That(actual.H[1, 2], Is.EqualTo(12.0));
+        }
+
+        [Test]
+        public void RoundTripNmfKeepsReconstructionBehavior()
+        {
+            var options = NumFlatJsonSerializerOptions.Create();
+            var source = CreateNmf();
+            var expected = source.W * source.H;
+
+            var json = JsonSerializer.Serialize(source, options);
+            var actual = JsonSerializer.Deserialize<NonnegativeMatrixFactorization>(json, options)!;
+            var actualReconstruction = actual.W * actual.H;
+
+            Assert.That(actualReconstruction[0, 0], Is.EqualTo(expected[0, 0]).Within(1.0e-12));
+            Assert.That(actualReconstruction[0, 1], Is.EqualTo(expected[0, 1]).Within(1.0e-12));
+            Assert.That(actualReconstruction[0, 2], Is.EqualTo(expected[0, 2]).Within(1.0e-12));
+            Assert.That(actualReconstruction[1, 0], Is.EqualTo(expected[1, 0]).Within(1.0e-12));
+            Assert.That(actualReconstruction[1, 1], Is.EqualTo(expected[1, 1]).Within(1.0e-12));
+            Assert.That(actualReconstruction[1, 2], Is.EqualTo(expected[1, 2]).Within(1.0e-12));
+            Assert.That(actualReconstruction[2, 0], Is.EqualTo(expected[2, 0]).Within(1.0e-12));
+            Assert.That(actualReconstruction[2, 1], Is.EqualTo(expected[2, 1]).Within(1.0e-12));
+            Assert.That(actualReconstruction[2, 2], Is.EqualTo(expected[2, 2]).Within(1.0e-12));
+        }
+
+        [Test]
+        public void DeserializeNmfHonorsCaseInsensitivePropertyNames()
+        {
+            var options = NumFlatJsonSerializerOptions.Create();
+            options.PropertyNameCaseInsensitive = true;
+            const string json = @"{""W"":[[1,2],[3,4],[5,6]],""H"":[[7,8,9],[10,11,12]]}";
+
+            var actual = JsonSerializer.Deserialize<NonnegativeMatrixFactorization>(json, options)!;
+
+            Assert.That(actual.W[2, 1], Is.EqualTo(6.0));
+            Assert.That(actual.H[1, 2], Is.EqualTo(12.0));
+        }
+
+        [Test]
+        public void DeserializeNmfWithInvalidShapeThrowsJsonException()
+        {
+            var options = NumFlatJsonSerializerOptions.Create();
+            const string json = @"{""w"":[[1,2],[3,4]],""h"":[[5,6],[7,8],[9,10]]}";
+
+            Assert.That((Action)(() => JsonSerializer.Deserialize<NonnegativeMatrixFactorization>(json, options)), Throws.TypeOf<JsonException>());
+        }
+
+        private static NonnegativeMatrixFactorization CreateNmf()
+        {
+            Mat<double> w =
+            [
+                [1.0, 2.0],
+                [3.0, 4.0],
+                [5.0, 6.0],
+            ];
+            Mat<double> h =
+            [
+                [7.0, 8.0, 9.0],
+                [10.0, 11.0, 12.0],
+            ];
+
+            return new NonnegativeMatrixFactorization(w, h);
+        }
+    }
+}


### PR DESCRIPTION
### Motivation

- Enable robust JSON (de)serialization of fitted multivariate models so persisted models can be reconstructed without refitting. 

### Description

- Add parameterized constructors to `CommonSpatialPattern`, `IndependentComponentAnalysis`, and `NonnegativeMatrixFactorization` that accept fitted parameters and validate shapes. 
- Change `CommonSpatialPattern` internals to store `eigenValues` and `eigenVectors` (replacing the prior GEVD field) and update `Transform`, properties, and dimension accessors accordingly. 
- Add JSON converters `CommonSpatialPatternJsonConverter`, `IndependentComponentAnalysisJsonConverter`, and `NonnegativeMatrixFactorizationJsonConverter`, and register them in `NumFlatJsonSerializerOptionsExtensions.AddNumFlatConverters`. 
- Add unit tests `CommonSpatialPatternTests`, `IndependentComponentAnalysisTests`, and `NonnegativeMatrixFactorizationTests` exercising round-trip serialization, preserved transform/reconstruction behavior, case-insensitive property names, and invalid-shape error cases. 

### Testing

- Ran the new serialization unit tests `CommonSpatialPatternTests`, `IndependentComponentAnalysisTests`, and `NonnegativeMatrixFactorizationTests`, and they all passed. 
- The added converters were exercised via `JsonSerializer` round-trip tests which validated both parameter equality and transform/reconstruction behavior and succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a06ae3eb1748326994dcb19867db28f)