### PR TITLE
Add JSON serialization for KMeans, GMM and DiagonalGMM

### DIFF
--- a/NumFlat/Clustering/DiagonalGaussianMixtureModel.cs
+++ b/NumFlat/Clustering/DiagonalGaussianMixtureModel.cs
@@ -40,6 +40,12 @@ namespace NumFlat.Clustering
                 throw new ArgumentException("Null components are not allowed.", nameof(components));
             }
 
+            var dimension = array[0].Gaussian.Dimension;
+            if (array.Any(component => component.Gaussian.Dimension != dimension))
+            {
+                throw new ArgumentException("All Gaussian components must have the same dimension.", nameof(components));
+            }
+
             this.components = array;
         }
 

--- a/NumFlat/Clustering/GaussianMixtureModel.cs
+++ b/NumFlat/Clustering/GaussianMixtureModel.cs
@@ -40,6 +40,12 @@ namespace NumFlat.Clustering
                 throw new ArgumentException("Null components are not allowed.", nameof(components));
             }
 
+            var dimension = array[0].Gaussian.Dimension;
+            if (array.Any(component => component.Gaussian.Dimension != dimension))
+            {
+                throw new ArgumentException("All Gaussian components must have the same dimension.", nameof(components));
+            }
+
             this.components = array;
         }
 

--- a/NumFlat/Clustering/KMeans.cs
+++ b/NumFlat/Clustering/KMeans.cs
@@ -12,9 +12,39 @@ namespace NumFlat.Clustering
     {
         private readonly Vec<double>[] centroids;
 
-        private KMeans(Vec<double>[] centroids)
+        /// <summary>
+        /// Creates a k-means model from fitted centroids.
+        /// </summary>
+        /// <param name="centroids">
+        /// The fitted centroids.
+        /// </param>
+        /// <remarks>
+        /// This constructor is intended primarily for deserializers that reconstruct a fitted model from persisted parameters.
+        /// The given vectors are stored directly, so they should not be mutated after construction.
+        /// </remarks>
+        public KMeans(IEnumerable<Vec<double>> centroids)
         {
-            this.centroids = centroids;
+            ThrowHelper.ThrowIfNull(centroids, nameof(centroids));
+
+            var array = centroids.ToArray();
+
+            if (array.Length == 0)
+            {
+                throw new ArgumentException("The number of clusters must be greater than or equal to one.", nameof(centroids));
+            }
+
+            var dimension = array[0].Count;
+            if (dimension == 0)
+            {
+                throw new ArgumentException("Empty centroid vectors are not allowed.", nameof(centroids));
+            }
+
+            if (array.Any(centroid => centroid.Count != dimension))
+            {
+                throw new ArgumentException("All centroid vectors must have the same length.", nameof(centroids));
+            }
+
+            this.centroids = array;
         }
 
         /// <summary>

--- a/SerializationJson/DiagonalGaussianMixtureModelJsonConverter.cs
+++ b/SerializationJson/DiagonalGaussianMixtureModelJsonConverter.cs
@@ -1,0 +1,263 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using NumFlat.Clustering;
+using NumFlat.Distributions;
+
+namespace NumFlat.Serialization.Json
+{
+    /// <summary>
+    /// Converts <see cref="DiagonalGaussianMixtureModel" /> instances to and from JSON.
+    /// </summary>
+    public sealed class DiagonalGaussianMixtureModelJsonConverter : JsonConverter<DiagonalGaussianMixtureModel>
+    {
+        private const string ComponentsPropertyName = "components";
+        private const string WeightPropertyName = "weight";
+        private const string GaussianPropertyName = "gaussian";
+        private const string MeanPropertyName = "mean";
+        private const string VariancePropertyName = "variance";
+
+        /// <inheritdoc />
+        public override DiagonalGaussianMixtureModel Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            if (reader.TokenType != JsonTokenType.StartObject)
+            {
+                throw new JsonException("A NumFlat diagonal GMM object must be represented as a JSON object.");
+            }
+
+            DiagonalGaussianMixtureModel.Component[]? components = null;
+
+            while (reader.Read())
+            {
+                if (reader.TokenType == JsonTokenType.EndObject)
+                {
+                    return CreateGmm(components);
+                }
+
+                if (reader.TokenType != JsonTokenType.PropertyName)
+                {
+                    throw new JsonException("A NumFlat diagonal GMM object property name is expected.");
+                }
+
+                var propertyName = reader.GetString();
+                if (!reader.Read())
+                {
+                    throw new JsonException("The JSON object for a NumFlat diagonal GMM object is incomplete.");
+                }
+
+                if (JsonSerializationHelpers.PropertyNameEquals(propertyName, ComponentsPropertyName, options))
+                {
+                    components = ReadComponents(ref reader, options);
+                }
+                else
+                {
+                    reader.Skip();
+                }
+            }
+
+            throw new JsonException("The JSON object for a NumFlat diagonal GMM object is incomplete.");
+        }
+
+        /// <inheritdoc />
+        public override void Write(Utf8JsonWriter writer, DiagonalGaussianMixtureModel value, JsonSerializerOptions options)
+        {
+            writer.WriteStartObject();
+            writer.WritePropertyName(ComponentsPropertyName);
+            writer.WriteStartArray();
+            foreach (var component in value.Components)
+            {
+                writer.WriteStartObject();
+                writer.WritePropertyName(WeightPropertyName);
+                JsonSerializer.Serialize(writer, component.Weight, options);
+                writer.WritePropertyName(GaussianPropertyName);
+                WriteGaussian(writer, component.Gaussian, options);
+                writer.WriteEndObject();
+            }
+            writer.WriteEndArray();
+            writer.WriteEndObject();
+        }
+
+        private static DiagonalGaussianMixtureModel.Component[] ReadComponents(ref Utf8JsonReader reader, JsonSerializerOptions options)
+        {
+            if (reader.TokenType != JsonTokenType.StartArray)
+            {
+                throw new JsonException("The 'components' property of a NumFlat diagonal GMM object must be a JSON array.");
+            }
+
+            var components = new List<DiagonalGaussianMixtureModel.Component>();
+            while (reader.Read())
+            {
+                if (reader.TokenType == JsonTokenType.EndArray)
+                {
+                    return components.ToArray();
+                }
+
+                components.Add(ReadComponent(ref reader, options));
+            }
+
+            throw new JsonException("The JSON array for NumFlat diagonal GMM components is incomplete.");
+        }
+
+        private static DiagonalGaussianMixtureModel.Component ReadComponent(ref Utf8JsonReader reader, JsonSerializerOptions options)
+        {
+            if (reader.TokenType != JsonTokenType.StartObject)
+            {
+                throw new JsonException("A NumFlat diagonal GMM component must be represented as a JSON object.");
+            }
+
+            double? weight = null;
+            DiagonalGaussian? gaussian = null;
+
+            while (reader.Read())
+            {
+                if (reader.TokenType == JsonTokenType.EndObject)
+                {
+                    return CreateComponent(weight, gaussian);
+                }
+
+                if (reader.TokenType != JsonTokenType.PropertyName)
+                {
+                    throw new JsonException("A NumFlat diagonal GMM component property name is expected.");
+                }
+
+                var propertyName = reader.GetString();
+                if (!reader.Read())
+                {
+                    throw new JsonException("The JSON object for a NumFlat diagonal GMM component is incomplete.");
+                }
+
+                if (JsonSerializationHelpers.PropertyNameEquals(propertyName, WeightPropertyName, options))
+                {
+                    weight = JsonSerializer.Deserialize<double>(ref reader, options);
+                }
+                else if (JsonSerializationHelpers.PropertyNameEquals(propertyName, GaussianPropertyName, options))
+                {
+                    gaussian = ReadGaussian(ref reader, options);
+                }
+                else
+                {
+                    reader.Skip();
+                }
+            }
+
+            throw new JsonException("The JSON object for a NumFlat diagonal GMM component is incomplete.");
+        }
+
+        private static DiagonalGaussian ReadGaussian(ref Utf8JsonReader reader, JsonSerializerOptions options)
+        {
+            if (reader.TokenType != JsonTokenType.StartObject)
+            {
+                throw new JsonException("A NumFlat diagonal Gaussian component distribution must be represented as a JSON object.");
+            }
+
+            Vec<double>? mean = null;
+            Vec<double>? variance = null;
+
+            while (reader.Read())
+            {
+                if (reader.TokenType == JsonTokenType.EndObject)
+                {
+                    return CreateGaussian(mean, variance);
+                }
+
+                if (reader.TokenType != JsonTokenType.PropertyName)
+                {
+                    throw new JsonException("A NumFlat diagonal Gaussian component distribution property name is expected.");
+                }
+
+                var propertyName = reader.GetString();
+                if (!reader.Read())
+                {
+                    throw new JsonException("The JSON object for a NumFlat diagonal Gaussian component distribution is incomplete.");
+                }
+
+                if (JsonSerializationHelpers.PropertyNameEquals(propertyName, MeanPropertyName, options))
+                {
+                    mean = JsonSerializer.Deserialize<Vec<double>>(ref reader, options);
+                }
+                else if (JsonSerializationHelpers.PropertyNameEquals(propertyName, VariancePropertyName, options))
+                {
+                    variance = JsonSerializer.Deserialize<Vec<double>>(ref reader, options);
+                }
+                else
+                {
+                    reader.Skip();
+                }
+            }
+
+            throw new JsonException("The JSON object for a NumFlat diagonal Gaussian component distribution is incomplete.");
+        }
+
+        private static void WriteGaussian(Utf8JsonWriter writer, DiagonalGaussian value, JsonSerializerOptions options)
+        {
+            writer.WriteStartObject();
+            writer.WritePropertyName(MeanPropertyName);
+            JsonSerializer.Serialize(writer, value.Mean, options);
+            writer.WritePropertyName(VariancePropertyName);
+            JsonSerializer.Serialize(writer, value.Variance, options);
+            writer.WriteEndObject();
+        }
+
+        private static DiagonalGaussianMixtureModel CreateGmm(DiagonalGaussianMixtureModel.Component[]? components)
+        {
+            if (components == null)
+            {
+                throw new JsonException("The JSON object for a NumFlat diagonal GMM object must contain a 'components' property.");
+            }
+
+            try
+            {
+                return new DiagonalGaussianMixtureModel(components);
+            }
+            catch (ArgumentException ex)
+            {
+                throw new JsonException("The JSON object cannot be converted to a NumFlat diagonal GMM object.", ex);
+            }
+        }
+
+        private static DiagonalGaussianMixtureModel.Component CreateComponent(double? weight, DiagonalGaussian? gaussian)
+        {
+            if (weight == null)
+            {
+                throw new JsonException("The JSON object for a NumFlat diagonal GMM component must contain a 'weight' property.");
+            }
+
+            if (gaussian == null)
+            {
+                throw new JsonException("The JSON object for a NumFlat diagonal GMM component must contain a 'gaussian' property.");
+            }
+
+            try
+            {
+                return new DiagonalGaussianMixtureModel.Component(weight.Value, gaussian);
+            }
+            catch (ArgumentException ex)
+            {
+                throw new JsonException("The JSON object cannot be converted to a NumFlat diagonal GMM component.", ex);
+            }
+        }
+
+        private static DiagonalGaussian CreateGaussian(Vec<double>? mean, Vec<double>? variance)
+        {
+            if (mean == null)
+            {
+                throw new JsonException("The JSON object for a NumFlat diagonal Gaussian component distribution must contain a 'mean' property.");
+            }
+
+            if (variance == null)
+            {
+                throw new JsonException("The JSON object for a NumFlat diagonal Gaussian component distribution must contain a 'variance' property.");
+            }
+
+            try
+            {
+                return new DiagonalGaussian(mean.Value, variance.Value);
+            }
+            catch (Exception ex) when (ex is ArgumentException || ex is FittingFailureException)
+            {
+                throw new JsonException("The JSON object cannot be converted to a NumFlat diagonal Gaussian component distribution.", ex);
+            }
+        }
+    }
+}

--- a/SerializationJson/GaussianMixtureModelJsonConverter.cs
+++ b/SerializationJson/GaussianMixtureModelJsonConverter.cs
@@ -1,0 +1,263 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using NumFlat.Clustering;
+using NumFlat.Distributions;
+
+namespace NumFlat.Serialization.Json
+{
+    /// <summary>
+    /// Converts <see cref="GaussianMixtureModel" /> instances to and from JSON.
+    /// </summary>
+    public sealed class GaussianMixtureModelJsonConverter : JsonConverter<GaussianMixtureModel>
+    {
+        private const string ComponentsPropertyName = "components";
+        private const string WeightPropertyName = "weight";
+        private const string GaussianPropertyName = "gaussian";
+        private const string MeanPropertyName = "mean";
+        private const string CovariancePropertyName = "covariance";
+
+        /// <inheritdoc />
+        public override GaussianMixtureModel Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            if (reader.TokenType != JsonTokenType.StartObject)
+            {
+                throw new JsonException("A NumFlat GMM object must be represented as a JSON object.");
+            }
+
+            GaussianMixtureModel.Component[]? components = null;
+
+            while (reader.Read())
+            {
+                if (reader.TokenType == JsonTokenType.EndObject)
+                {
+                    return CreateGmm(components);
+                }
+
+                if (reader.TokenType != JsonTokenType.PropertyName)
+                {
+                    throw new JsonException("A NumFlat GMM object property name is expected.");
+                }
+
+                var propertyName = reader.GetString();
+                if (!reader.Read())
+                {
+                    throw new JsonException("The JSON object for a NumFlat GMM object is incomplete.");
+                }
+
+                if (JsonSerializationHelpers.PropertyNameEquals(propertyName, ComponentsPropertyName, options))
+                {
+                    components = ReadComponents(ref reader, options);
+                }
+                else
+                {
+                    reader.Skip();
+                }
+            }
+
+            throw new JsonException("The JSON object for a NumFlat GMM object is incomplete.");
+        }
+
+        /// <inheritdoc />
+        public override void Write(Utf8JsonWriter writer, GaussianMixtureModel value, JsonSerializerOptions options)
+        {
+            writer.WriteStartObject();
+            writer.WritePropertyName(ComponentsPropertyName);
+            writer.WriteStartArray();
+            foreach (var component in value.Components)
+            {
+                writer.WriteStartObject();
+                writer.WritePropertyName(WeightPropertyName);
+                JsonSerializer.Serialize(writer, component.Weight, options);
+                writer.WritePropertyName(GaussianPropertyName);
+                WriteGaussian(writer, component.Gaussian, options);
+                writer.WriteEndObject();
+            }
+            writer.WriteEndArray();
+            writer.WriteEndObject();
+        }
+
+        private static GaussianMixtureModel.Component[] ReadComponents(ref Utf8JsonReader reader, JsonSerializerOptions options)
+        {
+            if (reader.TokenType != JsonTokenType.StartArray)
+            {
+                throw new JsonException("The 'components' property of a NumFlat GMM object must be a JSON array.");
+            }
+
+            var components = new List<GaussianMixtureModel.Component>();
+            while (reader.Read())
+            {
+                if (reader.TokenType == JsonTokenType.EndArray)
+                {
+                    return components.ToArray();
+                }
+
+                components.Add(ReadComponent(ref reader, options));
+            }
+
+            throw new JsonException("The JSON array for NumFlat GMM components is incomplete.");
+        }
+
+        private static GaussianMixtureModel.Component ReadComponent(ref Utf8JsonReader reader, JsonSerializerOptions options)
+        {
+            if (reader.TokenType != JsonTokenType.StartObject)
+            {
+                throw new JsonException("A NumFlat GMM component must be represented as a JSON object.");
+            }
+
+            double? weight = null;
+            Gaussian? gaussian = null;
+
+            while (reader.Read())
+            {
+                if (reader.TokenType == JsonTokenType.EndObject)
+                {
+                    return CreateComponent(weight, gaussian);
+                }
+
+                if (reader.TokenType != JsonTokenType.PropertyName)
+                {
+                    throw new JsonException("A NumFlat GMM component property name is expected.");
+                }
+
+                var propertyName = reader.GetString();
+                if (!reader.Read())
+                {
+                    throw new JsonException("The JSON object for a NumFlat GMM component is incomplete.");
+                }
+
+                if (JsonSerializationHelpers.PropertyNameEquals(propertyName, WeightPropertyName, options))
+                {
+                    weight = JsonSerializer.Deserialize<double>(ref reader, options);
+                }
+                else if (JsonSerializationHelpers.PropertyNameEquals(propertyName, GaussianPropertyName, options))
+                {
+                    gaussian = ReadGaussian(ref reader, options);
+                }
+                else
+                {
+                    reader.Skip();
+                }
+            }
+
+            throw new JsonException("The JSON object for a NumFlat GMM component is incomplete.");
+        }
+
+        private static Gaussian ReadGaussian(ref Utf8JsonReader reader, JsonSerializerOptions options)
+        {
+            if (reader.TokenType != JsonTokenType.StartObject)
+            {
+                throw new JsonException("A NumFlat Gaussian component distribution must be represented as a JSON object.");
+            }
+
+            Vec<double>? mean = null;
+            Mat<double>? covariance = null;
+
+            while (reader.Read())
+            {
+                if (reader.TokenType == JsonTokenType.EndObject)
+                {
+                    return CreateGaussian(mean, covariance);
+                }
+
+                if (reader.TokenType != JsonTokenType.PropertyName)
+                {
+                    throw new JsonException("A NumFlat Gaussian component distribution property name is expected.");
+                }
+
+                var propertyName = reader.GetString();
+                if (!reader.Read())
+                {
+                    throw new JsonException("The JSON object for a NumFlat Gaussian component distribution is incomplete.");
+                }
+
+                if (JsonSerializationHelpers.PropertyNameEquals(propertyName, MeanPropertyName, options))
+                {
+                    mean = JsonSerializer.Deserialize<Vec<double>>(ref reader, options);
+                }
+                else if (JsonSerializationHelpers.PropertyNameEquals(propertyName, CovariancePropertyName, options))
+                {
+                    covariance = JsonSerializer.Deserialize<Mat<double>>(ref reader, options);
+                }
+                else
+                {
+                    reader.Skip();
+                }
+            }
+
+            throw new JsonException("The JSON object for a NumFlat Gaussian component distribution is incomplete.");
+        }
+
+        private static void WriteGaussian(Utf8JsonWriter writer, Gaussian value, JsonSerializerOptions options)
+        {
+            writer.WriteStartObject();
+            writer.WritePropertyName(MeanPropertyName);
+            JsonSerializer.Serialize(writer, value.Mean, options);
+            writer.WritePropertyName(CovariancePropertyName);
+            JsonSerializer.Serialize(writer, value.Covariance, options);
+            writer.WriteEndObject();
+        }
+
+        private static GaussianMixtureModel CreateGmm(GaussianMixtureModel.Component[]? components)
+        {
+            if (components == null)
+            {
+                throw new JsonException("The JSON object for a NumFlat GMM object must contain a 'components' property.");
+            }
+
+            try
+            {
+                return new GaussianMixtureModel(components);
+            }
+            catch (ArgumentException ex)
+            {
+                throw new JsonException("The JSON object cannot be converted to a NumFlat GMM object.", ex);
+            }
+        }
+
+        private static GaussianMixtureModel.Component CreateComponent(double? weight, Gaussian? gaussian)
+        {
+            if (weight == null)
+            {
+                throw new JsonException("The JSON object for a NumFlat GMM component must contain a 'weight' property.");
+            }
+
+            if (gaussian == null)
+            {
+                throw new JsonException("The JSON object for a NumFlat GMM component must contain a 'gaussian' property.");
+            }
+
+            try
+            {
+                return new GaussianMixtureModel.Component(weight.Value, gaussian);
+            }
+            catch (ArgumentException ex)
+            {
+                throw new JsonException("The JSON object cannot be converted to a NumFlat GMM component.", ex);
+            }
+        }
+
+        private static Gaussian CreateGaussian(Vec<double>? mean, Mat<double>? covariance)
+        {
+            if (mean == null)
+            {
+                throw new JsonException("The JSON object for a NumFlat Gaussian component distribution must contain a 'mean' property.");
+            }
+
+            if (covariance == null)
+            {
+                throw new JsonException("The JSON object for a NumFlat Gaussian component distribution must contain a 'covariance' property.");
+            }
+
+            try
+            {
+                return new Gaussian(mean.Value, covariance.Value);
+            }
+            catch (Exception ex) when (ex is ArgumentException || ex is FittingFailureException || ex is MatrixFactorizationException)
+            {
+                throw new JsonException("The JSON object cannot be converted to a NumFlat Gaussian component distribution.", ex);
+            }
+        }
+    }
+}

--- a/SerializationJson/KMeansJsonConverter.cs
+++ b/SerializationJson/KMeansJsonConverter.cs
@@ -1,0 +1,82 @@
+﻿using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using NumFlat.Clustering;
+
+namespace NumFlat.Serialization.Json
+{
+    /// <summary>
+    /// Converts <see cref="KMeans" /> instances to and from JSON.
+    /// </summary>
+    public sealed class KMeansJsonConverter : JsonConverter<KMeans>
+    {
+        private const string CentroidsPropertyName = "centroids";
+
+        /// <inheritdoc />
+        public override KMeans Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            if (reader.TokenType != JsonTokenType.StartObject)
+            {
+                throw new JsonException("A NumFlat k-means object must be represented as a JSON object.");
+            }
+
+            Vec<double>[]? centroids = null;
+
+            while (reader.Read())
+            {
+                if (reader.TokenType == JsonTokenType.EndObject)
+                {
+                    return CreateKMeans(centroids);
+                }
+
+                if (reader.TokenType != JsonTokenType.PropertyName)
+                {
+                    throw new JsonException("A NumFlat k-means object property name is expected.");
+                }
+
+                var propertyName = reader.GetString();
+                if (!reader.Read())
+                {
+                    throw new JsonException("The JSON object for a NumFlat k-means object is incomplete.");
+                }
+
+                if (JsonSerializationHelpers.PropertyNameEquals(propertyName, CentroidsPropertyName, options))
+                {
+                    centroids = JsonSerializer.Deserialize<Vec<double>[]>(ref reader, options);
+                }
+                else
+                {
+                    reader.Skip();
+                }
+            }
+
+            throw new JsonException("The JSON object for a NumFlat k-means object is incomplete.");
+        }
+
+        /// <inheritdoc />
+        public override void Write(Utf8JsonWriter writer, KMeans value, JsonSerializerOptions options)
+        {
+            writer.WriteStartObject();
+            writer.WritePropertyName(CentroidsPropertyName);
+            JsonSerializer.Serialize(writer, value.Centroids, options);
+            writer.WriteEndObject();
+        }
+
+        private static KMeans CreateKMeans(Vec<double>[]? centroids)
+        {
+            if (centroids == null)
+            {
+                throw new JsonException("The JSON object for a NumFlat k-means object must contain a 'centroids' property.");
+            }
+
+            try
+            {
+                return new KMeans(centroids);
+            }
+            catch (ArgumentException ex)
+            {
+                throw new JsonException("The JSON object cannot be converted to a NumFlat k-means object.", ex);
+            }
+        }
+    }
+}

--- a/SerializationJson/NumFlatJsonSerializerOptionsExtensions.cs
+++ b/SerializationJson/NumFlatJsonSerializerOptionsExtensions.cs
@@ -27,6 +27,9 @@ namespace NumFlat.Serialization.Json
             JsonSerializationHelpers.AddConverterIfMissing<ComplexJsonConverter>(options);
             JsonSerializationHelpers.AddConverterIfMissing<VecJsonConverterFactory>(options);
             JsonSerializationHelpers.AddConverterIfMissing<MatJsonConverterFactory>(options);
+            JsonSerializationHelpers.AddConverterIfMissing<KMeansJsonConverter>(options);
+            JsonSerializationHelpers.AddConverterIfMissing<GaussianMixtureModelJsonConverter>(options);
+            JsonSerializationHelpers.AddConverterIfMissing<DiagonalGaussianMixtureModelJsonConverter>(options);
             JsonSerializationHelpers.AddConverterIfMissing<PrincipalComponentAnalysisJsonConverter>(options);
             JsonSerializationHelpers.AddConverterIfMissing<LinearDiscriminantAnalysisJsonConverter>(options);
             JsonSerializationHelpers.AddConverterIfMissing<CommonSpatialPatternJsonConverter>(options);

--- a/SerializationJsonTest/ClusteringTests.cs
+++ b/SerializationJsonTest/ClusteringTests.cs
@@ -1,0 +1,136 @@
+using System;
+using System.Linq;
+using System.Text.Json;
+using NumFlat;
+using NumFlat.Clustering;
+using NumFlat.Distributions;
+using NumFlat.Serialization.Json;
+
+namespace SerializationJsonTest
+{
+    public class ClusteringTests
+    {
+        [Test]
+        public void RoundTripKMeansKeepsFittedParametersAndPredictBehavior()
+        {
+            var options = NumFlatJsonSerializerOptions.Create();
+            var source = new KMeans(new[]
+            {
+                new Vec<double>(new[] { 1.0, 2.0 }),
+                new Vec<double>(new[] { 10.0, 20.0 })
+            });
+            var x = new Vec<double>(new[] { 2.0, 3.0 });
+
+            var json = JsonSerializer.Serialize(source, options);
+            var actual = JsonSerializer.Deserialize<KMeans>(json, options)!;
+
+            Assert.That(json, Is.EqualTo(@"{""centroids"":[[1,2],[10,20]]}"));
+            Assert.That(actual.Centroids[0].ToArray(), Is.EqualTo(new[] { 1.0, 2.0 }));
+            Assert.That(actual.Centroids[1].ToArray(), Is.EqualTo(new[] { 10.0, 20.0 }));
+            Assert.That(actual.Predict(x), Is.EqualTo(source.Predict(x)));
+        }
+
+        [Test]
+        public void DeserializeKMeansWithInvalidShapeThrowsJsonException()
+        {
+            var options = NumFlatJsonSerializerOptions.Create();
+            const string json = @"{""centroids"":[[1,2],[3]]}";
+
+            Assert.That((Action)(() => JsonSerializer.Deserialize<KMeans>(json, options)), Throws.TypeOf<JsonException>());
+        }
+
+        [Test]
+        public void RoundTripGmmKeepsFittedParametersAndPredictionBehavior()
+        {
+            var options = NumFlatJsonSerializerOptions.Create();
+            var source = CreateGmm();
+            var x = new Vec<double>(new[] { 1.2, 2.1 });
+            var expectedProbabilities = source.PredictProbability(x);
+
+            var json = JsonSerializer.Serialize(source, options);
+            var actual = JsonSerializer.Deserialize<GaussianMixtureModel>(json, options)!;
+            var actualProbabilities = actual.PredictProbability(x);
+
+            Assert.That(json, Is.EqualTo(@"{""components"":[{""weight"":0.4,""gaussian"":{""mean"":[1,2],""covariance"":[[2,0.1],[0.1,3]]}},{""weight"":0.6,""gaussian"":{""mean"":[10,20],""covariance"":[[4,0.2],[0.2,5]]}}]}"));
+            Assert.That(actual.Components[0].Weight, Is.EqualTo(0.4));
+            Assert.That(actual.Components[0].Gaussian.Mean.ToArray(), Is.EqualTo(new[] { 1.0, 2.0 }));
+            Assert.That(actual.Components[0].Gaussian.Covariance[0, 1], Is.EqualTo(0.1));
+            Assert.That(actual.Components[1].Weight, Is.EqualTo(0.6));
+            Assert.That(actual.Predict(x), Is.EqualTo(source.Predict(x)));
+            Assert.That(actualProbabilities.ToArray(), Is.EqualTo(expectedProbabilities.ToArray()).Within(1.0e-12));
+        }
+
+        [Test]
+        public void DeserializeGmmWithInvalidShapeThrowsJsonException()
+        {
+            var options = NumFlatJsonSerializerOptions.Create();
+            const string json = @"{""components"":[{""weight"":1,""gaussian"":{""mean"":[1,2],""covariance"":[[1,0],[0,1]]}},{""weight"":1,""gaussian"":{""mean"":[3],""covariance"":[[1]]}}]}";
+
+            Assert.That((Action)(() => JsonSerializer.Deserialize<GaussianMixtureModel>(json, options)), Throws.TypeOf<JsonException>());
+        }
+
+        [Test]
+        public void RoundTripDiagonalGmmKeepsFittedParametersAndPredictionBehavior()
+        {
+            var options = NumFlatJsonSerializerOptions.Create();
+            var source = CreateDiagonalGmm();
+            var x = new Vec<double>(new[] { 1.2, 2.1 });
+            var expectedProbabilities = source.PredictProbability(x);
+
+            var json = JsonSerializer.Serialize(source, options);
+            var actual = JsonSerializer.Deserialize<DiagonalGaussianMixtureModel>(json, options)!;
+            var actualProbabilities = actual.PredictProbability(x);
+
+            Assert.That(json, Is.EqualTo(@"{""components"":[{""weight"":0.4,""gaussian"":{""mean"":[1,2],""variance"":[2,3]}},{""weight"":0.6,""gaussian"":{""mean"":[10,20],""variance"":[4,5]}}]}"));
+            Assert.That(actual.Components[0].Weight, Is.EqualTo(0.4));
+            Assert.That(actual.Components[0].Gaussian.Mean.ToArray(), Is.EqualTo(new[] { 1.0, 2.0 }));
+            Assert.That(actual.Components[0].Gaussian.Variance.ToArray(), Is.EqualTo(new[] { 2.0, 3.0 }));
+            Assert.That(actual.Components[1].Weight, Is.EqualTo(0.6));
+            Assert.That(actual.Predict(x), Is.EqualTo(source.Predict(x)));
+            Assert.That(actualProbabilities.ToArray(), Is.EqualTo(expectedProbabilities.ToArray()).Within(1.0e-12));
+        }
+
+        [Test]
+        public void DeserializeDiagonalGmmWithInvalidShapeThrowsJsonException()
+        {
+            var options = NumFlatJsonSerializerOptions.Create();
+            const string json = @"{""components"":[{""weight"":1,""gaussian"":{""mean"":[1,2],""variance"":[1,1]}},{""weight"":1,""gaussian"":{""mean"":[3],""variance"":[1]}}]}";
+
+            Assert.That((Action)(() => JsonSerializer.Deserialize<DiagonalGaussianMixtureModel>(json, options)), Throws.TypeOf<JsonException>());
+        }
+
+        private static GaussianMixtureModel CreateGmm()
+        {
+            var component1 = new GaussianMixtureModel.Component(
+                0.4,
+                new Gaussian(
+                    new Vec<double>(new[] { 1.0, 2.0 }),
+                    new Mat<double>(2, 2, 2, new[]
+                    {
+                        2.0, 0.1,
+                        0.1, 3.0
+                    })));
+            var component2 = new GaussianMixtureModel.Component(
+                0.6,
+                new Gaussian(
+                    new Vec<double>(new[] { 10.0, 20.0 }),
+                    new Mat<double>(2, 2, 2, new[]
+                    {
+                        4.0, 0.2,
+                        0.2, 5.0
+                    })));
+            return new GaussianMixtureModel(new[] { component1, component2 });
+        }
+
+        private static DiagonalGaussianMixtureModel CreateDiagonalGmm()
+        {
+            var component1 = new DiagonalGaussianMixtureModel.Component(
+                0.4,
+                new DiagonalGaussian(new Vec<double>(new[] { 1.0, 2.0 }), new Vec<double>(new[] { 2.0, 3.0 })));
+            var component2 = new DiagonalGaussianMixtureModel.Component(
+                0.6,
+                new DiagonalGaussian(new Vec<double>(new[] { 10.0, 20.0 }), new Vec<double>(new[] { 4.0, 5.0 })));
+            return new DiagonalGaussianMixtureModel(new[] { component1, component2 });
+        }
+    }
+}

--- a/SerializationJsonTest/NumFlatJsonSerializerOptionsTests.cs
+++ b/SerializationJsonTest/NumFlatJsonSerializerOptionsTests.cs
@@ -15,6 +15,9 @@ namespace SerializationJsonTest
 
             Assert.That(options.Converters.OfType<VecJsonConverterFactory>().Count(), Is.EqualTo(1));
             Assert.That(options.Converters.OfType<MatJsonConverterFactory>().Count(), Is.EqualTo(1));
+            Assert.That(options.Converters.OfType<KMeansJsonConverter>().Count(), Is.EqualTo(1));
+            Assert.That(options.Converters.OfType<GaussianMixtureModelJsonConverter>().Count(), Is.EqualTo(1));
+            Assert.That(options.Converters.OfType<DiagonalGaussianMixtureModelJsonConverter>().Count(), Is.EqualTo(1));
             Assert.That(options.Converters.OfType<PrincipalComponentAnalysisJsonConverter>().Count(), Is.EqualTo(1));
             Assert.That(options.Converters.OfType<LinearDiscriminantAnalysisJsonConverter>().Count(), Is.EqualTo(1));
         }


### PR DESCRIPTION
### Motivation
- Provide System.Text.Json-based serialize/deserialize support for clustering models (k-means, GMM and diagonal GMM) similar to existing PCA/LDA/ICA converters so fitted models can be persisted and restored.
- Ensure safe deserialization by validating shapes and dimensions when reconstructing models from JSON.

### Description
- Added JSON converters `KMeansJsonConverter`, `GaussianMixtureModelJsonConverter`, and `DiagonalGaussianMixtureModelJsonConverter` under `SerializationJson/` to serialize and deserialize model parameters (e.g. `centroids`, component `weight` + `gaussian` `mean`/`covariance` or `variance`).
- Registered the new converters in `AddNumFlatConverters()` by updating `SerializationJson/NumFlatJsonSerializerOptionsExtensions.cs` so they are included via `NumFlatJsonSerializerOptions.Create()`.
- Added a public fitted-centroid constructor `public KMeans(IEnumerable<Vec<double>> centroids)` that is intended for deserializers and validates empty/unequal-length centroids before storing them.
- Added dimension consistency checks in the `GaussianMixtureModel` and `DiagonalGaussianMixtureModel` constructors to reject component lists whose Gaussians have mismatched dimensions.
- Added unit tests (`SerializationJsonTest/ClusteringTests.cs`) to assert round-trip serialization, preserved prediction behavior, and that invalid shapes raise `JsonException`; updated `NumFlatJsonSerializerOptionsTests` to include the new converters.

### Testing
- Ran `dotnet test SerializationJsonTest/SerializationJsonTest.csproj --no-restore`, which passed (51 tests passed).
- Ran `dotnet test NumFlatTest/NumFlatTest.csproj --no-restore`, which passed (3521 tests passed).
- A full solution-level `dotnet test NumFlat.slnx` was attempted but failed in this environment due to the `.slnx` format handling, so individual project tests were run and succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a06b6d4bc7c83268386101a67ced7fd)