### PR TITLE
Add AsSingleElementMatrix/AsSingleElementVector extensions and tests

### DIFF
--- a/NumFlat/Mat/MatrixBuilder.cs
+++ b/NumFlat/Mat/MatrixBuilder.cs
@@ -205,6 +205,27 @@ namespace NumFlat
             return identity;
         }
 
+
+        /// <summary>
+        /// Creates a 1x1 matrix that contains the specified element.
+        /// </summary>
+        /// <typeparam name="T">
+        /// The type of elements in the matrix.
+        /// </typeparam>
+        /// <param name="element">
+        /// The element for the new matrix.
+        /// </param>
+        /// <returns>
+        /// A new 1x1 matrix containing only <paramref name="element"/>.
+        /// </returns>
+        /// <remarks>
+        /// This method allocates a single-element array and creates a matrix from it.
+        /// </remarks>
+        public static Mat<T> AsSingleElementMatrix<T>(this T element) where T : unmanaged, INumberBase<T>
+        {
+            return new Mat<T>(1, 1, 1, new T[] { element });
+        }
+
         /// <summary>
         /// Creates a new matrix from the specified elements.
         /// </summary>

--- a/NumFlat/Vec/VectorBuilder.cs
+++ b/NumFlat/Vec/VectorBuilder.cs
@@ -10,6 +10,27 @@ namespace NumFlat
     /// </summary>
     public static class VectorBuilder
     {
+
+        /// <summary>
+        /// Creates a one-dimensional vector that contains the specified element.
+        /// </summary>
+        /// <typeparam name="T">
+        /// The type of elements in the vector.
+        /// </typeparam>
+        /// <param name="element">
+        /// The element for the new vector.
+        /// </param>
+        /// <returns>
+        /// A new vector containing only <paramref name="element"/>.
+        /// </returns>
+        /// <remarks>
+        /// This method allocates a single-element array and creates a vector from it.
+        /// </remarks>
+        public static Vec<T> AsSingleElementVector<T>(this T element) where T : unmanaged, INumberBase<T>
+        {
+            return new Vec<T>(new T[] { element });
+        }
+
         /// <summary>
         /// Creates a new vector from the specified elements.
         /// </summary>

--- a/NumFlatTest/MatTests/MatrixBuilderTests.cs
+++ b/NumFlatTest/MatTests/MatrixBuilderTests.cs
@@ -98,6 +98,20 @@ namespace NumFlatTest.MatTests
             }
         }
 
+
+        [Test]
+        public void AsSingleElementMatrix()
+        {
+            const int expected = 42;
+
+            var actual = expected.AsSingleElementMatrix();
+
+            Assert.That(actual.RowCount, Is.EqualTo(1));
+            Assert.That(actual.ColCount, Is.EqualTo(1));
+            Assert.That(actual[0, 0], Is.EqualTo(expected));
+            Assert.That(actual.Memory.ToArray(), Is.EqualTo(new[] { expected }));
+        }
+
         [TestCase(1, 1)]
         [TestCase(2, 2)]
         [TestCase(2, 4)]

--- a/NumFlatTest/VecTests/VectorBuilderTests.cs
+++ b/NumFlatTest/VecTests/VectorBuilderTests.cs
@@ -33,6 +33,19 @@ namespace NumFlatTest.VecTests
             Assert.That(actual, Is.EqualTo(expected));
         }
 
+
+        [Test]
+        public void AsSingleElementVector()
+        {
+            const int expected = 42;
+
+            var actual = expected.AsSingleElementVector();
+
+            Assert.That(actual.Count, Is.EqualTo(1));
+            Assert.That(actual[0], Is.EqualTo(expected));
+            Assert.That(actual.Memory.ToArray(), Is.EqualTo(new[] { expected }));
+        }
+
         [Test]
         public void ToVector()
         {


### PR DESCRIPTION
### Motivation
- Provide convenience methods to construct a 1x1 `Mat<T>` and a single-element `Vec<T>` directly from a scalar for API ergonomics.
- Ensure the single-element storage is allocated as a single-element array so the returned `Memory<T>` contains its own backing storage.

### Description
- Added `AsSingleElementVector<T>(this T element)` to `VectorBuilder` returning `new Vec<T>(new T[] { element })`.
- Added `AsSingleElementMatrix<T>(this T element)` to `MatrixBuilder` returning `new Mat<T>(1, 1, 1, new T[] { element })` to match the `Mat` constructor that accepts `stride` and `Memory<T>`.
- Added unit tests `AsSingleElementVector` and `AsSingleElementMatrix` that verify count/dimensions, element value, and underlying `Memory` contents.
- Kept allocations minimal and consistent with existing constructors by passing explicit `stride` and a single-element array as `Memory` backing.

### Testing
- Ran `dotnet test NumFlatTest/NumFlatTest.csproj --filter "FullyQualifiedName~VectorBuilderTests|FullyQualifiedName~MatrixBuilderTests"`.
- The filtered test run completed successfully with `Passed: 59`, `Failed: 0`, and `Skipped: 0`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a119ef8be448326a3b9fdb1011f80af)