### PR TITLE
Replace kernel delegate with extensible Kernel classes and add Linear/Polynomial/Gaussian implementations

### DIFF
--- a/NumFlat/Kernel.cs
+++ b/NumFlat/Kernel.cs
@@ -11,16 +11,132 @@ namespace NumFlat
     /// <typeparam name="U">
     /// The type of the second argument.
     /// </typeparam>
-    /// <param name="x">
-    /// The first object to compare.
-    /// </param>
-    /// <param name="y">
-    /// The second object to compare.
-    /// </param>
-    /// <returns>
-    /// The computed kernel value.
-    /// </returns>
-    public delegate double Kernel<T, U>(T x, U y);
+    public abstract class Kernel<T, U>
+    {
+        /// <summary>
+        /// Computes the kernel value between two objects.
+        /// </summary>
+        /// <param name="x">
+        /// The first object to compare.
+        /// </param>
+        /// <param name="y">
+        /// The second object to compare.
+        /// </param>
+        /// <returns>
+        /// The computed kernel value.
+        /// </returns>
+        public abstract double Invoke(T x, U y);
+    }
+
+
+
+    /// <summary>
+    /// Represents the linear kernel.
+    /// </summary>
+    public sealed class LinearKernel : Kernel<Vec<double>, Vec<double>>
+    {
+        /// <inheritdoc/>
+        public override double Invoke(Vec<double> x, Vec<double> y)
+        {
+            ThrowHelper.ThrowIfEmpty(x, nameof(x));
+            ThrowHelper.ThrowIfEmpty(y, nameof(y));
+            ThrowHelper.ThrowIfDifferentSize(x, y);
+
+            return x * y;
+        }
+    }
+
+
+
+    /// <summary>
+    /// Represents a polynomial kernel.
+    /// </summary>
+    public sealed class PolynomialKernel : Kernel<Vec<double>, Vec<double>>
+    {
+        private readonly int degree;
+        private readonly double constant;
+
+        /// <summary>
+        /// Creates a polynomial kernel.
+        /// </summary>
+        /// <param name="degree">
+        /// The degree of the polynomial.
+        /// </param>
+        /// <param name="constant">
+        /// The constant term of the polynomial.
+        /// </param>
+        public PolynomialKernel(int degree, double constant)
+        {
+            if (degree <= 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(degree), "The degree must be greater than zero.");
+            }
+
+            this.degree = degree;
+            this.constant = constant;
+        }
+
+        /// <inheritdoc/>
+        public override double Invoke(Vec<double> x, Vec<double> y)
+        {
+            ThrowHelper.ThrowIfEmpty(x, nameof(x));
+            ThrowHelper.ThrowIfEmpty(y, nameof(y));
+            ThrowHelper.ThrowIfDifferentSize(x, y);
+
+            return Math.Pow(x * y + constant, degree);
+        }
+
+        /// <summary>
+        /// Gets the degree of the polynomial.
+        /// </summary>
+        public int Degree => degree;
+
+        /// <summary>
+        /// Gets the constant term of the polynomial.
+        /// </summary>
+        public double Constant => constant;
+    }
+
+
+
+    /// <summary>
+    /// Represents a Gaussian radial basis function (RBF) kernel.
+    /// </summary>
+    public sealed class GaussianKernel : Kernel<Vec<double>, Vec<double>>
+    {
+        private readonly double gamma;
+
+        /// <summary>
+        /// Creates a Gaussian radial basis function (RBF) kernel.
+        /// </summary>
+        /// <param name="gamma">
+        /// The gamma parameter of the kernel.
+        /// </param>
+        public GaussianKernel(double gamma)
+        {
+            if (gamma <= 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(gamma), "The gamma parameter must be greater than zero.");
+            }
+
+            this.gamma = gamma;
+        }
+
+        /// <inheritdoc/>
+        public override double Invoke(Vec<double> x, Vec<double> y)
+        {
+            ThrowHelper.ThrowIfEmpty(x, nameof(x));
+            ThrowHelper.ThrowIfEmpty(y, nameof(y));
+            ThrowHelper.ThrowIfDifferentSize(x, y);
+
+            return Math.Exp(-gamma * x.DistanceSquared(y));
+        }
+
+        /// <summary>
+        /// Gets the gamma parameter of the kernel.
+        /// </summary>
+        public double Gamma => gamma;
+    }
 
 
 
@@ -30,16 +146,15 @@ namespace NumFlat
     public static class Kernel
     {
         /// <summary>
-        /// Gets the linear kernel.
+        /// Creates a linear kernel.
         /// </summary>
-        public static Kernel<Vec<double>, Vec<double>> Linear => (Vec<double> x, Vec<double> y) =>
+        /// <returns>
+        /// The linear kernel.
+        /// </returns>
+        public static LinearKernel Linear()
         {
-            ThrowHelper.ThrowIfEmpty(x, nameof(x));
-            ThrowHelper.ThrowIfEmpty(y, nameof(y));
-            ThrowHelper.ThrowIfDifferentSize(x, y);
-
-            return x * y;
-        };
+            return new LinearKernel();
+        }
 
         /// <summary>
         /// Creates a polynomial kernel.
@@ -53,21 +168,9 @@ namespace NumFlat
         /// <returns>
         /// The polynomial kernel.
         /// </returns>
-        public static Kernel<Vec<double>, Vec<double>> Polynomial(int degree, double constant)
+        public static PolynomialKernel Polynomial(int degree, double constant)
         {
-            if (degree <= 0)
-            {
-                throw new ArgumentOutOfRangeException(nameof(degree), "The degree must be greater than zero.");
-            }
-
-            return (Vec<double> x, Vec<double> y) =>
-            {
-                ThrowHelper.ThrowIfEmpty(x, nameof(x));
-                ThrowHelper.ThrowIfEmpty(y, nameof(y));
-                ThrowHelper.ThrowIfDifferentSize(x, y);
-
-                return Math.Pow(x * y + constant, degree);
-            };
+            return new PolynomialKernel(degree, constant);
         }
 
         /// <summary>
@@ -79,21 +182,9 @@ namespace NumFlat
         /// <returns>
         /// The Gaussian kernel.
         /// </returns>
-        public static Kernel<Vec<double>, Vec<double>> Gaussian(double gamma)
+        public static GaussianKernel Gaussian(double gamma)
         {
-            if (gamma <= 0)
-            {
-                throw new ArgumentOutOfRangeException(nameof(gamma), "The gamma parameter must be greater than zero.");
-            }
-
-            return (Vec<double> x, Vec<double> y) =>
-            {
-                ThrowHelper.ThrowIfEmpty(x, nameof(x));
-                ThrowHelper.ThrowIfEmpty(y, nameof(y));
-                ThrowHelper.ThrowIfDifferentSize(x, y);
-
-                return Math.Exp(-gamma * x.DistanceSquared(y));
-            };
+            return new GaussianKernel(gamma);
         }
     }
 }

--- a/NumFlat/MultivariateAnalyses/KernelPrincipalComponentAnalysis.cs
+++ b/NumFlat/MultivariateAnalyses/KernelPrincipalComponentAnalysis.cs
@@ -48,7 +48,7 @@ namespace NumFlat.MultivariateAnalyses
                 for (var j = 0; j <= i; j++)
                 {
                     var vec2 = sourceVectors.Cols[j];
-                    var value = kernel(vec1, vec2);
+                    var value = kernel.Invoke(vec1, vec2);
                     fkmat[i, j] = value;
                     fkmat[j, i] = value;
                 }
@@ -123,7 +123,7 @@ namespace NumFlat.MultivariateAnalyses
             var sum = 0.0;
             for (var i = 0; i < sourceVectors.ColCount; i++)
             {
-                var value = kernel(sourceVectors.Cols[i], source);
+                var value = kernel.Invoke(sourceVectors.Cols[i], source);
                 ftmp[i] = value;
                 sum += value;
             }

--- a/NumFlatTest/KernelTests.cs
+++ b/NumFlatTest/KernelTests.cs
@@ -1,0 +1,36 @@
+﻿using NUnit.Framework;
+using NumFlat;
+
+namespace NumFlatTest
+{
+    public class KernelTests
+    {
+        [Test]
+        public void Polynomial_ReturnsReadableParameters()
+        {
+            var kernel = Kernel.Polynomial(3, 2.0);
+
+            Assert.That(kernel.Degree, Is.EqualTo(3));
+            Assert.That(kernel.Constant, Is.EqualTo(2.0));
+        }
+
+        [Test]
+        public void Gaussian_ReturnsReadableParameters()
+        {
+            var kernel = Kernel.Gaussian(0.5);
+
+            Assert.That(kernel.Gamma, Is.EqualTo(0.5));
+        }
+
+        [Test]
+        public void Invoke_ComputesKernelValues()
+        {
+            var x = new[] { 1.0, 2.0 }.ToVector();
+            var y = new[] { 3.0, 4.0 }.ToVector();
+
+            Assert.That(Kernel.Linear().Invoke(x, y), Is.EqualTo(11.0).Within(1.0E-12));
+            Assert.That(Kernel.Polynomial(2, 1.0).Invoke(x, y), Is.EqualTo(144.0).Within(1.0E-12));
+            Assert.That(Kernel.Gaussian(0.5).Invoke(x, y), Is.EqualTo(System.Math.Exp(-4.0)).Within(1.0E-12));
+        }
+    }
+}

--- a/NumFlatTest/MultivariateAnalysesTests/KernelPcaTests.cs
+++ b/NumFlatTest/MultivariateAnalysesTests/KernelPcaTests.cs
@@ -71,7 +71,7 @@ namespace NumFlatTest.MultivariateAnalysesTests
             var pca = dataset.Pca();
             var reference = dataset.Select(x => pca.Transform(x)[0..2]).ToArray();
 
-            var kPca = dataset.KernelPca(Kernel.Linear);
+            var kPca = dataset.KernelPca(Kernel.Linear());
 
             var transformed = dataset.Select(x =>
             {


### PR DESCRIPTION
### Motivation
- Replace the simple `Kernel<T,U>` delegate with an extensible, object-oriented representation to allow kernels to carry parameters and behavior. 
- Expose kernel parameters (degree, constant, gamma) so tests and callers can inspect them. 
- Provide a small set of common kernel implementations (linear, polynomial, Gaussian RBF) and simple factory helpers for ergonomic creation. 

### Description
- Replaced the `public delegate double Kernel<T, U>(T x, U y)` with an abstract class `Kernel<T, U>` exposing an abstract `Invoke(T x, U y)` method. 
- Added concrete kernel types `LinearKernel`, `PolynomialKernel`, and `GaussianKernel` with implementations of `Invoke` and read-only properties `Degree`, `Constant`, and `Gamma` where applicable. 
- Added a static factory class `Kernel` with `Linear()`, `Polynomial(int degree, double constant)`, and `Gaussian(double gamma)` methods that construct the corresponding kernel objects. 
- Updated usages to call `kernel.Invoke(...)` (notably `KernelPrincipalComponentAnalysis`) and updated tests to use the new factories and properties (`Kernel.Linear()`, `Kernel.Polynomial(...)`, `Kernel.Gaussian(...)`). 

### Testing
- Added `NumFlatTest/KernelTests.cs` covering parameter exposure and numeric results for the three kernels and ran it as part of the unit test suite. 
- Updated `KernelPcaTests` to use the new kernel factories and ran the multivariate analysis tests that exercise `KernelPrincipalComponentAnalysis`. 
- Ran the automated test suite (`dotnet test`) and the updated tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2631f436588326834a21440b5aa023)