### PR TITLE
Add JSON serialization support for Kernel and KernelPrincipalComponentAnalysis with tests

### DIFF
--- a/NumFlat/MultivariateAnalyses/KernelPrincipalComponentAnalysis.cs
+++ b/NumFlat/MultivariateAnalyses/KernelPrincipalComponentAnalysis.cs
@@ -100,6 +100,53 @@ namespace NumFlat.MultivariateAnalyses
             this.projection = projection;
         }
 
+
+        /// <summary>
+        /// Creates kernel principal component analysis (kernel PCA) from fitted parameters.
+        /// </summary>
+        /// <param name="sourceVectors">
+        /// The source vectors stored as columns.
+        /// </param>
+        /// <param name="kernel">
+        /// The kernel function applied to the vectors.
+        /// </param>
+        /// <param name="kernelMeans">
+        /// The mean kernel value for each source vector.
+        /// </param>
+        /// <param name="totalMean">
+        /// The total mean of the kernel matrix.
+        /// </param>
+        /// <param name="projection">
+        /// The projection matrix.
+        /// </param>
+        /// <remarks>
+        /// This constructor is intended primarily for deserializers that reconstruct a fitted model from persisted parameters.
+        /// The given vectors and matrices are stored directly, so they should not be mutated after construction.
+        /// </remarks>
+        public KernelPrincipalComponentAnalysis(in Mat<double> sourceVectors, Kernel<Vec<double>, Vec<double>> kernel, in Vec<double> kernelMeans, double totalMean, in Mat<double> projection)
+        {
+            ThrowHelper.ThrowIfEmpty(sourceVectors, nameof(sourceVectors));
+            ThrowHelper.ThrowIfNull(kernel, nameof(kernel));
+            ThrowHelper.ThrowIfEmpty(kernelMeans, nameof(kernelMeans));
+            ThrowHelper.ThrowIfEmpty(projection, nameof(projection));
+
+            if (kernelMeans.Count != sourceVectors.ColCount)
+            {
+                throw new ArgumentException($"The length of the kernel mean vector must be {sourceVectors.ColCount}, but was {kernelMeans.Count}.", nameof(kernelMeans));
+            }
+
+            if (projection.RowCount != sourceVectors.ColCount || projection.ColCount != sourceVectors.ColCount)
+            {
+                throw new ArgumentException($"The projection matrix must be {sourceVectors.ColCount} x {sourceVectors.ColCount}, but was {projection.RowCount} x {projection.ColCount}.", nameof(projection));
+            }
+
+            this.sourceVectors = sourceVectors;
+            this.kernel = kernel;
+            this.kernelMeans = kernelMeans;
+            this.totalMean = totalMean;
+            this.projection = projection;
+        }
+
         /// <inheritdoc/>
         public void Transform(in Vec<double> source, in Vec<double> destination)
         {
@@ -138,6 +185,32 @@ namespace NumFlat.MultivariateAnalyses
             var components = projection[.., ..destination.Count];
             Mat.Mul(components, tmp, destination, true);
         }
+
+
+        /// <summary>
+        /// Gets the source vectors stored as columns.
+        /// </summary>
+        public ref readonly Mat<double> SourceVectors => ref sourceVectors;
+
+        /// <summary>
+        /// Gets the kernel function applied to the vectors.
+        /// </summary>
+        public Kernel<Vec<double>, Vec<double>> Kernel => kernel;
+
+        /// <summary>
+        /// Gets the mean kernel value for each source vector.
+        /// </summary>
+        public ref readonly Vec<double> KernelMeans => ref kernelMeans;
+
+        /// <summary>
+        /// Gets the total mean of the kernel matrix.
+        /// </summary>
+        public double TotalMean => totalMean;
+
+        /// <summary>
+        /// Gets the projection matrix.
+        /// </summary>
+        public ref readonly Mat<double> Projection => ref projection;
 
         /// <inheritdoc/>
         public int SourceDimension => sourceVectors.RowCount;

--- a/SerializationJson/KernelJsonConverter.cs
+++ b/SerializationJson/KernelJsonConverter.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace NumFlat.Serialization.Json
+{
+    /// <summary>
+    /// Converts built-in <see cref="Kernel{T, U}" /> instances for double vectors to and from JSON.
+    /// </summary>
+    public sealed class KernelJsonConverter : JsonConverter<Kernel<Vec<double>, Vec<double>>>
+    {
+        /// <inheritdoc />
+        public override Kernel<Vec<double>, Vec<double>> Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            return KernelJsonSerialization.Read(ref reader, options, "NumFlat kernel object");
+        }
+
+        /// <inheritdoc />
+        public override void Write(Utf8JsonWriter writer, Kernel<Vec<double>, Vec<double>> value, JsonSerializerOptions options)
+        {
+            KernelJsonSerialization.Write(writer, value, options);
+        }
+    }
+}

--- a/SerializationJson/KernelJsonSerialization.cs
+++ b/SerializationJson/KernelJsonSerialization.cs
@@ -1,0 +1,144 @@
+﻿using System;
+using System.Text.Json;
+
+namespace NumFlat.Serialization.Json
+{
+    internal static class KernelJsonSerialization
+    {
+        private const string TypePropertyName = "type";
+        private const string DegreePropertyName = "degree";
+        private const string ConstantPropertyName = "constant";
+        private const string GammaPropertyName = "gamma";
+        private const string LinearTypeName = "linear";
+        private const string PolynomialTypeName = "polynomial";
+        private const string GaussianTypeName = "gaussian";
+
+        public static Kernel<Vec<double>, Vec<double>> Read(ref Utf8JsonReader reader, JsonSerializerOptions options, string objectDescription)
+        {
+            if (reader.TokenType != JsonTokenType.StartObject)
+            {
+                throw new JsonException($"A {objectDescription} must be represented as a JSON object.");
+            }
+
+            string? type = null;
+            int? degree = null;
+            double? constant = null;
+            double? gamma = null;
+
+            while (reader.Read())
+            {
+                if (reader.TokenType == JsonTokenType.EndObject)
+                {
+                    return Create(type, degree, constant, gamma, objectDescription);
+                }
+
+                if (reader.TokenType != JsonTokenType.PropertyName)
+                {
+                    throw new JsonException($"A {objectDescription} property name is expected.");
+                }
+
+                var propertyName = reader.GetString();
+                if (!reader.Read())
+                {
+                    throw new JsonException($"The JSON object for a {objectDescription} is incomplete.");
+                }
+
+                if (JsonSerializationHelpers.PropertyNameEquals(propertyName, TypePropertyName, options))
+                {
+                    type = reader.GetString();
+                }
+                else if (JsonSerializationHelpers.PropertyNameEquals(propertyName, DegreePropertyName, options))
+                {
+                    degree = reader.GetInt32();
+                }
+                else if (JsonSerializationHelpers.PropertyNameEquals(propertyName, ConstantPropertyName, options))
+                {
+                    constant = reader.GetDouble();
+                }
+                else if (JsonSerializationHelpers.PropertyNameEquals(propertyName, GammaPropertyName, options))
+                {
+                    gamma = reader.GetDouble();
+                }
+                else
+                {
+                    reader.Skip();
+                }
+            }
+
+            throw new JsonException($"The JSON object for a {objectDescription} is incomplete.");
+        }
+
+        public static void Write(Utf8JsonWriter writer, Kernel<Vec<double>, Vec<double>> value, JsonSerializerOptions options)
+        {
+            writer.WriteStartObject();
+
+            switch (value)
+            {
+                case LinearKernel:
+                    writer.WriteString(TypePropertyName, LinearTypeName);
+                    break;
+
+                case PolynomialKernel polynomial:
+                    writer.WriteString(TypePropertyName, PolynomialTypeName);
+                    writer.WriteNumber(DegreePropertyName, polynomial.Degree);
+                    writer.WriteNumber(ConstantPropertyName, polynomial.Constant);
+                    break;
+
+                case GaussianKernel gaussian:
+                    writer.WriteString(TypePropertyName, GaussianTypeName);
+                    writer.WriteNumber(GammaPropertyName, gaussian.Gamma);
+                    break;
+
+                default:
+                    throw new NotSupportedException($"The kernel type '{value.GetType()}' is not supported by NumFlat JSON serialization.");
+            }
+
+            writer.WriteEndObject();
+        }
+
+        private static Kernel<Vec<double>, Vec<double>> Create(string? type, int? degree, double? constant, double? gamma, string objectDescription)
+        {
+            if (type == null)
+            {
+                throw new JsonException($"The JSON object for a {objectDescription} must contain a 'type' property.");
+            }
+
+            try
+            {
+                switch (type)
+                {
+                    case LinearTypeName:
+                        return new LinearKernel();
+
+                    case PolynomialTypeName:
+                        if (degree == null)
+                        {
+                            throw new JsonException($"The JSON object for a {objectDescription} with type 'polynomial' must contain a 'degree' property.");
+                        }
+
+                        if (constant == null)
+                        {
+                            throw new JsonException($"The JSON object for a {objectDescription} with type 'polynomial' must contain a 'constant' property.");
+                        }
+
+                        return new PolynomialKernel(degree.Value, constant.Value);
+
+                    case GaussianTypeName:
+                        if (gamma == null)
+                        {
+                            throw new JsonException($"The JSON object for a {objectDescription} with type 'gaussian' must contain a 'gamma' property.");
+                        }
+
+                        return new GaussianKernel(gamma.Value);
+
+                    default:
+                        throw new JsonException($"The JSON object for a {objectDescription} contains an unsupported kernel type '{type}'.");
+                }
+            }
+            catch (ArgumentException ex)
+            {
+                throw new JsonException($"The JSON object cannot be converted to a {objectDescription}.", ex);
+            }
+        }
+    }
+}

--- a/SerializationJson/KernelPrincipalComponentAnalysisJsonConverter.cs
+++ b/SerializationJson/KernelPrincipalComponentAnalysisJsonConverter.cs
@@ -1,0 +1,134 @@
+﻿using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using NumFlat.MultivariateAnalyses;
+
+namespace NumFlat.Serialization.Json
+{
+    /// <summary>
+    /// Converts <see cref="KernelPrincipalComponentAnalysis" /> instances to and from JSON.
+    /// </summary>
+    public sealed class KernelPrincipalComponentAnalysisJsonConverter : JsonConverter<KernelPrincipalComponentAnalysis>
+    {
+        private const string SourceVectorsPropertyName = "sourceVectors";
+        private const string KernelPropertyName = "kernel";
+        private const string KernelMeansPropertyName = "kernelMeans";
+        private const string TotalMeanPropertyName = "totalMean";
+        private const string ProjectionPropertyName = "projection";
+
+        /// <inheritdoc />
+        public override KernelPrincipalComponentAnalysis Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            if (reader.TokenType != JsonTokenType.StartObject)
+            {
+                throw new JsonException("A NumFlat kernel PCA object must be represented as a JSON object.");
+            }
+
+            Mat<double>? sourceVectors = null;
+            Kernel<Vec<double>, Vec<double>>? kernel = null;
+            Vec<double>? kernelMeans = null;
+            double? totalMean = null;
+            Mat<double>? projection = null;
+
+            while (reader.Read())
+            {
+                if (reader.TokenType == JsonTokenType.EndObject)
+                {
+                    return CreateKernelPca(sourceVectors, kernel, kernelMeans, totalMean, projection);
+                }
+
+                if (reader.TokenType != JsonTokenType.PropertyName)
+                {
+                    throw new JsonException("A NumFlat kernel PCA object property name is expected.");
+                }
+
+                var propertyName = reader.GetString();
+                if (!reader.Read())
+                {
+                    throw new JsonException("The JSON object for a NumFlat kernel PCA object is incomplete.");
+                }
+
+                if (JsonSerializationHelpers.PropertyNameEquals(propertyName, SourceVectorsPropertyName, options))
+                {
+                    sourceVectors = JsonSerializationHelpers.ReadDoubleMatrix(ref reader);
+                }
+                else if (JsonSerializationHelpers.PropertyNameEquals(propertyName, KernelPropertyName, options))
+                {
+                    kernel = KernelJsonSerialization.Read(ref reader, options, "NumFlat kernel PCA kernel");
+                }
+                else if (JsonSerializationHelpers.PropertyNameEquals(propertyName, KernelMeansPropertyName, options))
+                {
+                    kernelMeans = JsonSerializationHelpers.ReadDoubleVector(ref reader);
+                }
+                else if (JsonSerializationHelpers.PropertyNameEquals(propertyName, TotalMeanPropertyName, options))
+                {
+                    totalMean = reader.GetDouble();
+                }
+                else if (JsonSerializationHelpers.PropertyNameEquals(propertyName, ProjectionPropertyName, options))
+                {
+                    projection = JsonSerializationHelpers.ReadDoubleMatrix(ref reader);
+                }
+                else
+                {
+                    reader.Skip();
+                }
+            }
+
+            throw new JsonException("The JSON object for a NumFlat kernel PCA object is incomplete.");
+        }
+
+        /// <inheritdoc />
+        public override void Write(Utf8JsonWriter writer, KernelPrincipalComponentAnalysis value, JsonSerializerOptions options)
+        {
+            writer.WriteStartObject();
+            writer.WritePropertyName(SourceVectorsPropertyName);
+            JsonSerializationHelpers.WriteDoubleMatrix(writer, value.SourceVectors);
+            writer.WritePropertyName(KernelPropertyName);
+            KernelJsonSerialization.Write(writer, value.Kernel, options);
+            writer.WritePropertyName(KernelMeansPropertyName);
+            JsonSerializationHelpers.WriteDoubleVector(writer, value.KernelMeans);
+            writer.WritePropertyName(TotalMeanPropertyName);
+            writer.WriteNumberValue(value.TotalMean);
+            writer.WritePropertyName(ProjectionPropertyName);
+            JsonSerializationHelpers.WriteDoubleMatrix(writer, value.Projection);
+            writer.WriteEndObject();
+        }
+
+        private static KernelPrincipalComponentAnalysis CreateKernelPca(Mat<double>? sourceVectors, Kernel<Vec<double>, Vec<double>>? kernel, Vec<double>? kernelMeans, double? totalMean, Mat<double>? projection)
+        {
+            if (sourceVectors == null)
+            {
+                throw new JsonException("The JSON object for a NumFlat kernel PCA object must contain a 'sourceVectors' property.");
+            }
+
+            if (kernel == null)
+            {
+                throw new JsonException("The JSON object for a NumFlat kernel PCA object must contain a 'kernel' property.");
+            }
+
+            if (kernelMeans == null)
+            {
+                throw new JsonException("The JSON object for a NumFlat kernel PCA object must contain a 'kernelMeans' property.");
+            }
+
+            if (totalMean == null)
+            {
+                throw new JsonException("The JSON object for a NumFlat kernel PCA object must contain a 'totalMean' property.");
+            }
+
+            if (projection == null)
+            {
+                throw new JsonException("The JSON object for a NumFlat kernel PCA object must contain a 'projection' property.");
+            }
+
+            try
+            {
+                return new KernelPrincipalComponentAnalysis(sourceVectors.Value, kernel, kernelMeans.Value, totalMean.Value, projection.Value);
+            }
+            catch (ArgumentException ex)
+            {
+                throw new JsonException("The JSON object cannot be converted to a NumFlat kernel PCA object.", ex);
+            }
+        }
+    }
+}

--- a/SerializationJson/NumFlatJsonSerializerContext.cs
+++ b/SerializationJson/NumFlatJsonSerializerContext.cs
@@ -25,7 +25,9 @@ namespace NumFlat.Serialization.Json
         typeof(KMeansJsonConverter),
         typeof(GaussianMixtureModelJsonConverter),
         typeof(DiagonalGaussianMixtureModelJsonConverter),
+        typeof(KernelJsonConverter),
         typeof(PrincipalComponentAnalysisJsonConverter),
+        typeof(KernelPrincipalComponentAnalysisJsonConverter),
         typeof(LinearDiscriminantAnalysisJsonConverter),
         typeof(CommonSpatialPatternJsonConverter),
         typeof(IndependentComponentAnalysisJsonConverter),
@@ -53,7 +55,9 @@ namespace NumFlat.Serialization.Json
     [JsonSerializable(typeof(DiagonalGaussianMixtureModel), TypeInfoPropertyName = "DiagonalGaussianMixtureModel")]
     [JsonSerializable(typeof(DiagonalGaussianMixtureModel.Component), TypeInfoPropertyName = "DiagonalGaussianMixtureModelComponent")]
     [JsonSerializable(typeof(System.Collections.Generic.IReadOnlyList<DiagonalGaussianMixtureModel.Component>), TypeInfoPropertyName = "DiagonalGaussianMixtureModelComponentList")]
+    [JsonSerializable(typeof(Kernel<Vec<double>, Vec<double>>), TypeInfoPropertyName = "DoubleVectorKernel")]
     [JsonSerializable(typeof(PrincipalComponentAnalysis))]
+    [JsonSerializable(typeof(KernelPrincipalComponentAnalysis))]
     [JsonSerializable(typeof(LinearDiscriminantAnalysis))]
     [JsonSerializable(typeof(CommonSpatialPattern))]
     [JsonSerializable(typeof(IndependentComponentAnalysis))]

--- a/SerializationJson/NumFlatJsonSerializerOptionsExtensions.cs
+++ b/SerializationJson/NumFlatJsonSerializerOptionsExtensions.cs
@@ -38,7 +38,9 @@ namespace NumFlat.Serialization.Json
             JsonSerializationHelpers.AddConverterIfMissing<KMeansJsonConverter>(options);
             JsonSerializationHelpers.AddConverterIfMissing<GaussianMixtureModelJsonConverter>(options);
             JsonSerializationHelpers.AddConverterIfMissing<DiagonalGaussianMixtureModelJsonConverter>(options);
+            JsonSerializationHelpers.AddConverterIfMissing<KernelJsonConverter>(options);
             JsonSerializationHelpers.AddConverterIfMissing<PrincipalComponentAnalysisJsonConverter>(options);
+            JsonSerializationHelpers.AddConverterIfMissing<KernelPrincipalComponentAnalysisJsonConverter>(options);
             JsonSerializationHelpers.AddConverterIfMissing<LinearDiscriminantAnalysisJsonConverter>(options);
             JsonSerializationHelpers.AddConverterIfMissing<CommonSpatialPatternJsonConverter>(options);
             JsonSerializationHelpers.AddConverterIfMissing<IndependentComponentAnalysisJsonConverter>(options);

--- a/SerializationJsonTest/KernelPrincipalComponentAnalysisTests.cs
+++ b/SerializationJsonTest/KernelPrincipalComponentAnalysisTests.cs
@@ -1,0 +1,77 @@
+using System;
+using System.Linq;
+using System.Text.Json;
+using NumFlat;
+using NumFlat.MultivariateAnalyses;
+using NumFlat.Serialization.Json;
+
+namespace SerializationJsonTest
+{
+    public class KernelPrincipalComponentAnalysisTests
+    {
+        [Test]
+        public void RoundTripKernelPcaKeepsFittedParameters()
+        {
+            var options = NumFlatJsonSerializerOptions.Create();
+            var source = CreateKernelPca();
+
+            var json = JsonSerializer.Serialize(source, options);
+            var actual = JsonSerializer.Deserialize<KernelPrincipalComponentAnalysis>(json, options)!;
+
+            Assert.That(json, Is.EqualTo(@"{""sourceVectors"":[[1,3],[2,4]],""kernel"":{""type"":""gaussian"",""gamma"":0.5},""kernelMeans"":[5,6],""totalMean"":7,""projection"":[[1,0],[0,1]]}"));
+            Assert.That(actual.SourceVectors[0, 0], Is.EqualTo(1.0));
+            Assert.That(actual.SourceVectors[1, 0], Is.EqualTo(2.0));
+            Assert.That(actual.SourceVectors[0, 1], Is.EqualTo(3.0));
+            Assert.That(actual.SourceVectors[1, 1], Is.EqualTo(4.0));
+            Assert.That(actual.Kernel, Is.TypeOf<GaussianKernel>());
+            Assert.That(((GaussianKernel)actual.Kernel).Gamma, Is.EqualTo(0.5));
+            Assert.That(actual.KernelMeans.ToArray(), Is.EqualTo(new[] { 5.0, 6.0 }));
+            Assert.That(actual.TotalMean, Is.EqualTo(7.0));
+            Assert.That(actual.Projection[0, 0], Is.EqualTo(1.0));
+            Assert.That(actual.Projection[0, 1], Is.EqualTo(0.0));
+            Assert.That(actual.Projection[1, 0], Is.EqualTo(0.0));
+            Assert.That(actual.Projection[1, 1], Is.EqualTo(1.0));
+        }
+
+        [Test]
+        public void RoundTripKernelPcaKeepsTransformBehavior()
+        {
+            var options = NumFlatJsonSerializerOptions.Create();
+            var source = CreateKernelPca();
+            var x = new Vec<double>(new[] { 5.0, 6.0 });
+            var expected = source.Transform(x);
+
+            var json = JsonSerializer.Serialize(source, options);
+            var actual = JsonSerializer.Deserialize<KernelPrincipalComponentAnalysis>(json, options)!;
+            var actualTransformed = actual.Transform(x);
+
+            Assert.That(actualTransformed.ToArray(), Is.EqualTo(expected.ToArray()).Within(1.0e-12));
+        }
+
+        [Test]
+        public void DeserializeKernelPcaWithInvalidShapeThrowsJsonException()
+        {
+            var options = NumFlatJsonSerializerOptions.Create();
+            const string json = @"{""sourceVectors"":[[1,3],[2,4]],""kernel"":{""type"":""linear""},""kernelMeans"":[5],""totalMean"":7,""projection"":[[1,0],[0,1]]}";
+
+            Assert.That((Action)(() => JsonSerializer.Deserialize<KernelPrincipalComponentAnalysis>(json, options)), Throws.TypeOf<JsonException>());
+        }
+
+        private static KernelPrincipalComponentAnalysis CreateKernelPca()
+        {
+            var sourceVectors = new Mat<double>(2, 2, 2, new[]
+            {
+                1.0, 2.0,
+                3.0, 4.0
+            });
+            var kernelMeans = new Vec<double>(new[] { 5.0, 6.0 });
+            var projection = new Mat<double>(2, 2, 2, new[]
+            {
+                1.0, 0.0,
+                0.0, 1.0
+            });
+
+            return new KernelPrincipalComponentAnalysis(sourceVectors, Kernel.Gaussian(0.5), kernelMeans, 7.0, projection);
+        }
+    }
+}

--- a/SerializationJsonTest/KernelTests.cs
+++ b/SerializationJsonTest/KernelTests.cs
@@ -1,0 +1,81 @@
+using System;
+using System.Text.Json;
+using NumFlat;
+using NumFlat.Serialization.Json;
+
+namespace SerializationJsonTest
+{
+    public class KernelTests
+    {
+        [Test]
+        public void RoundTripLinearKernelKeepsBehavior()
+        {
+            var options = NumFlatJsonSerializerOptions.Create();
+            Kernel<Vec<double>, Vec<double>> source = Kernel.Linear();
+
+            var json = JsonSerializer.Serialize(source, options);
+            var actual = JsonSerializer.Deserialize<Kernel<Vec<double>, Vec<double>>>(json, options)!;
+
+            Assert.That(json, Is.EqualTo(@"{""type"":""linear""}"));
+            Assert.That(actual, Is.TypeOf<LinearKernel>());
+            AssertKernelBehavior(actual, source);
+        }
+
+        [Test]
+        public void RoundTripPolynomialKernelKeepsParametersAndBehavior()
+        {
+            var options = NumFlatJsonSerializerOptions.Create();
+            Kernel<Vec<double>, Vec<double>> source = Kernel.Polynomial(3, 1.5);
+
+            var json = JsonSerializer.Serialize(source, options);
+            var actual = JsonSerializer.Deserialize<Kernel<Vec<double>, Vec<double>>>(json, options)!;
+            var polynomial = (PolynomialKernel)actual;
+
+            Assert.That(json, Is.EqualTo(@"{""type"":""polynomial"",""degree"":3,""constant"":1.5}"));
+            Assert.That(polynomial.Degree, Is.EqualTo(3));
+            Assert.That(polynomial.Constant, Is.EqualTo(1.5));
+            AssertKernelBehavior(actual, source);
+        }
+
+        [Test]
+        public void RoundTripGaussianKernelKeepsParametersAndBehavior()
+        {
+            var options = NumFlatJsonSerializerOptions.Create();
+            Kernel<Vec<double>, Vec<double>> source = Kernel.Gaussian(0.5);
+
+            var json = JsonSerializer.Serialize(source, options);
+            var actual = JsonSerializer.Deserialize<Kernel<Vec<double>, Vec<double>>>(json, options)!;
+            var gaussian = (GaussianKernel)actual;
+
+            Assert.That(json, Is.EqualTo(@"{""type"":""gaussian"",""gamma"":0.5}"));
+            Assert.That(gaussian.Gamma, Is.EqualTo(0.5));
+            AssertKernelBehavior(actual, source);
+        }
+
+        [Test]
+        public void DeserializeKernelWithUnknownTypeThrowsJsonException()
+        {
+            var options = NumFlatJsonSerializerOptions.Create();
+            const string json = @"{""type"":""sigmoid""}";
+
+            Assert.That((Action)(() => JsonSerializer.Deserialize<Kernel<Vec<double>, Vec<double>>>(json, options)), Throws.TypeOf<JsonException>());
+        }
+
+        [Test]
+        public void DeserializePolynomialKernelWithoutRequiredPropertyThrowsJsonException()
+        {
+            var options = NumFlatJsonSerializerOptions.Create();
+            const string json = @"{""type"":""polynomial"",""degree"":3}";
+
+            Assert.That((Action)(() => JsonSerializer.Deserialize<Kernel<Vec<double>, Vec<double>>>(json, options)), Throws.TypeOf<JsonException>());
+        }
+
+        private static void AssertKernelBehavior(Kernel<Vec<double>, Vec<double>> actual, Kernel<Vec<double>, Vec<double>> expected)
+        {
+            var x = new Vec<double>(new[] { 1.0, 2.0 });
+            var y = new Vec<double>(new[] { 3.0, 4.0 });
+
+            Assert.That(actual.Invoke(x, y), Is.EqualTo(expected.Invoke(x, y)).Within(1.0e-12));
+        }
+    }
+}

--- a/SerializationJsonTest/NumFlatJsonSerializerOptionsTests.cs
+++ b/SerializationJsonTest/NumFlatJsonSerializerOptionsTests.cs
@@ -26,7 +26,9 @@ namespace SerializationJsonTest
             Assert.That(options.Converters.OfType<KMeansJsonConverter>().Count(), Is.EqualTo(1));
             Assert.That(options.Converters.OfType<GaussianMixtureModelJsonConverter>().Count(), Is.EqualTo(1));
             Assert.That(options.Converters.OfType<DiagonalGaussianMixtureModelJsonConverter>().Count(), Is.EqualTo(1));
+            Assert.That(options.Converters.OfType<KernelJsonConverter>().Count(), Is.EqualTo(1));
             Assert.That(options.Converters.OfType<PrincipalComponentAnalysisJsonConverter>().Count(), Is.EqualTo(1));
+            Assert.That(options.Converters.OfType<KernelPrincipalComponentAnalysisJsonConverter>().Count(), Is.EqualTo(1));
             Assert.That(options.Converters.OfType<LinearDiscriminantAnalysisJsonConverter>().Count(), Is.EqualTo(1));
         }
 


### PR DESCRIPTION
### Motivation

- Enable JSON round-trip serialization for built-in kernel types and fitted kernel PCA models to support persistence and interop.
- Provide a deserialization path that reconstructs a fitted `KernelPrincipalComponentAnalysis` from persisted parameters for use in consumers and tests.

### Description

- Added `KernelJsonConverter` and `KernelJsonSerialization` to (de)serialize `Kernel<Vec<double>, Vec<double>>` instances including `LinearKernel`, `PolynomialKernel`, and `GaussianKernel` and their parameters using a compact `{ "type": ... }` object format.
- Added `KernelPrincipalComponentAnalysisJsonConverter` to (de)serialize `KernelPrincipalComponentAnalysis` objects including `sourceVectors`, `kernel`, `kernelMeans`, `totalMean`, and `projection` fields and wired it into the source-generated `NumFlatJsonSerializerContext` and `AddNumFlatConverters` extension.
- Extended `KernelPrincipalComponentAnalysis` with a new constructor that accepts fitted parameters (`sourceVectors`, `kernel`, `kernelMeans`, `totalMean`, `projection`) and with read-only accessors `SourceVectors`, `Kernel`, `KernelMeans`, `TotalMean`, and `Projection`; the constructor validates shapes and null/empty inputs.
- Added unit tests `KernelTests`, `KernelPrincipalComponentAnalysisTests`, and updated `NumFlatJsonSerializerOptionsTests` to verify parameter round-trips, behavior preservation, error handling for malformed input, and that converters are not duplicated in `AddNumFlatConverters`.

### Testing

- Ran `SerializationJsonTest.KernelTests` which verifies round-trip serialization for linear, polynomial, and gaussian kernels and behavior equality, and it passed.
- Ran `SerializationJsonTest.KernelPrincipalComponentAnalysisTests` which verifies parameter round-trip, transform behavior preservation, and invalid-shape deserialization error, and it passed.
- Ran `SerializationJsonTest.NumFlatJsonSerializerOptionsTests` which verifies `AddNumFlatConverters` does not add duplicate converters, and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2637f0be6483268371b1ce5fdb9d31)