### PR TITLE
Serialize only training data and kernel for KernelPCA; remove fitted-parameter deserialization

### DIFF
--- a/NumFlat/MultivariateAnalyses/KernelPrincipalComponentAnalysis.cs
+++ b/NumFlat/MultivariateAnalyses/KernelPrincipalComponentAnalysis.cs
@@ -101,52 +101,6 @@ namespace NumFlat.MultivariateAnalyses
         }
 
 
-        /// <summary>
-        /// Creates kernel principal component analysis (kernel PCA) from fitted parameters.
-        /// </summary>
-        /// <param name="sourceVectors">
-        /// The source vectors stored as columns.
-        /// </param>
-        /// <param name="kernel">
-        /// The kernel function applied to the vectors.
-        /// </param>
-        /// <param name="kernelMeans">
-        /// The mean kernel value for each source vector.
-        /// </param>
-        /// <param name="totalMean">
-        /// The total mean of the kernel matrix.
-        /// </param>
-        /// <param name="projection">
-        /// The projection matrix.
-        /// </param>
-        /// <remarks>
-        /// This constructor is intended primarily for deserializers that reconstruct a fitted model from persisted parameters.
-        /// The given vectors and matrices are stored directly, so they should not be mutated after construction.
-        /// </remarks>
-        public KernelPrincipalComponentAnalysis(in Mat<double> sourceVectors, Kernel<Vec<double>, Vec<double>> kernel, in Vec<double> kernelMeans, double totalMean, in Mat<double> projection)
-        {
-            ThrowHelper.ThrowIfEmpty(sourceVectors, nameof(sourceVectors));
-            ThrowHelper.ThrowIfNull(kernel, nameof(kernel));
-            ThrowHelper.ThrowIfEmpty(kernelMeans, nameof(kernelMeans));
-            ThrowHelper.ThrowIfEmpty(projection, nameof(projection));
-
-            if (kernelMeans.Count != sourceVectors.ColCount)
-            {
-                throw new ArgumentException($"The length of the kernel mean vector must be {sourceVectors.ColCount}, but was {kernelMeans.Count}.", nameof(kernelMeans));
-            }
-
-            if (projection.RowCount != sourceVectors.ColCount || projection.ColCount != sourceVectors.ColCount)
-            {
-                throw new ArgumentException($"The projection matrix must be {sourceVectors.ColCount} x {sourceVectors.ColCount}, but was {projection.RowCount} x {projection.ColCount}.", nameof(projection));
-            }
-
-            this.sourceVectors = sourceVectors;
-            this.kernel = kernel;
-            this.kernelMeans = kernelMeans;
-            this.totalMean = totalMean;
-            this.projection = projection;
-        }
-
         /// <inheritdoc/>
         public void Transform(in Vec<double> source, in Vec<double> destination)
         {

--- a/SerializationJson/KernelPrincipalComponentAnalysisJsonConverter.cs
+++ b/SerializationJson/KernelPrincipalComponentAnalysisJsonConverter.cs
@@ -12,9 +12,6 @@ namespace NumFlat.Serialization.Json
     {
         private const string SourceVectorsPropertyName = "sourceVectors";
         private const string KernelPropertyName = "kernel";
-        private const string KernelMeansPropertyName = "kernelMeans";
-        private const string TotalMeanPropertyName = "totalMean";
-        private const string ProjectionPropertyName = "projection";
 
         /// <inheritdoc />
         public override KernelPrincipalComponentAnalysis Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
@@ -26,15 +23,12 @@ namespace NumFlat.Serialization.Json
 
             Mat<double>? sourceVectors = null;
             Kernel<Vec<double>, Vec<double>>? kernel = null;
-            Vec<double>? kernelMeans = null;
-            double? totalMean = null;
-            Mat<double>? projection = null;
 
             while (reader.Read())
             {
                 if (reader.TokenType == JsonTokenType.EndObject)
                 {
-                    return CreateKernelPca(sourceVectors, kernel, kernelMeans, totalMean, projection);
+                    return CreateKernelPca(sourceVectors, kernel);
                 }
 
                 if (reader.TokenType != JsonTokenType.PropertyName)
@@ -56,18 +50,6 @@ namespace NumFlat.Serialization.Json
                 {
                     kernel = KernelJsonSerialization.Read(ref reader, options, "NumFlat kernel PCA kernel");
                 }
-                else if (JsonSerializationHelpers.PropertyNameEquals(propertyName, KernelMeansPropertyName, options))
-                {
-                    kernelMeans = JsonSerializationHelpers.ReadDoubleVector(ref reader);
-                }
-                else if (JsonSerializationHelpers.PropertyNameEquals(propertyName, TotalMeanPropertyName, options))
-                {
-                    totalMean = reader.GetDouble();
-                }
-                else if (JsonSerializationHelpers.PropertyNameEquals(propertyName, ProjectionPropertyName, options))
-                {
-                    projection = JsonSerializationHelpers.ReadDoubleMatrix(ref reader);
-                }
                 else
                 {
                     reader.Skip();
@@ -85,16 +67,10 @@ namespace NumFlat.Serialization.Json
             JsonSerializationHelpers.WriteDoubleMatrix(writer, value.SourceVectors);
             writer.WritePropertyName(KernelPropertyName);
             KernelJsonSerialization.Write(writer, value.Kernel, options);
-            writer.WritePropertyName(KernelMeansPropertyName);
-            JsonSerializationHelpers.WriteDoubleVector(writer, value.KernelMeans);
-            writer.WritePropertyName(TotalMeanPropertyName);
-            writer.WriteNumberValue(value.TotalMean);
-            writer.WritePropertyName(ProjectionPropertyName);
-            JsonSerializationHelpers.WriteDoubleMatrix(writer, value.Projection);
             writer.WriteEndObject();
         }
 
-        private static KernelPrincipalComponentAnalysis CreateKernelPca(Mat<double>? sourceVectors, Kernel<Vec<double>, Vec<double>>? kernel, Vec<double>? kernelMeans, double? totalMean, Mat<double>? projection)
+        private static KernelPrincipalComponentAnalysis CreateKernelPca(Mat<double>? sourceVectors, Kernel<Vec<double>, Vec<double>>? kernel)
         {
             if (sourceVectors == null)
             {
@@ -106,24 +82,9 @@ namespace NumFlat.Serialization.Json
                 throw new JsonException("The JSON object for a NumFlat kernel PCA object must contain a 'kernel' property.");
             }
 
-            if (kernelMeans == null)
-            {
-                throw new JsonException("The JSON object for a NumFlat kernel PCA object must contain a 'kernelMeans' property.");
-            }
-
-            if (totalMean == null)
-            {
-                throw new JsonException("The JSON object for a NumFlat kernel PCA object must contain a 'totalMean' property.");
-            }
-
-            if (projection == null)
-            {
-                throw new JsonException("The JSON object for a NumFlat kernel PCA object must contain a 'projection' property.");
-            }
-
             try
             {
-                return new KernelPrincipalComponentAnalysis(sourceVectors.Value, kernel, kernelMeans.Value, totalMean.Value, projection.Value);
+                return new KernelPrincipalComponentAnalysis(sourceVectors.Value.Cols, kernel);
             }
             catch (ArgumentException ex)
             {

--- a/SerializationJsonTest/KernelPrincipalComponentAnalysisTests.cs
+++ b/SerializationJsonTest/KernelPrincipalComponentAnalysisTests.cs
@@ -10,7 +10,7 @@ namespace SerializationJsonTest
     public class KernelPrincipalComponentAnalysisTests
     {
         [Test]
-        public void RoundTripKernelPcaKeepsFittedParameters()
+        public void RoundTripKernelPcaStoresTrainingDataAndKernelOnly()
         {
             var options = NumFlatJsonSerializerOptions.Create();
             var source = CreateKernelPca();
@@ -18,23 +18,17 @@ namespace SerializationJsonTest
             var json = JsonSerializer.Serialize(source, options);
             var actual = JsonSerializer.Deserialize<KernelPrincipalComponentAnalysis>(json, options)!;
 
-            Assert.That(json, Is.EqualTo(@"{""sourceVectors"":[[1,3],[2,4]],""kernel"":{""type"":""gaussian"",""gamma"":0.5},""kernelMeans"":[5,6],""totalMean"":7,""projection"":[[1,0],[0,1]]}"));
+            Assert.That(json, Is.EqualTo(@"{""sourceVectors"":[[1,3],[2,4]],""kernel"":{""type"":""gaussian"",""gamma"":0.5}}"));
             Assert.That(actual.SourceVectors[0, 0], Is.EqualTo(1.0));
             Assert.That(actual.SourceVectors[1, 0], Is.EqualTo(2.0));
             Assert.That(actual.SourceVectors[0, 1], Is.EqualTo(3.0));
             Assert.That(actual.SourceVectors[1, 1], Is.EqualTo(4.0));
             Assert.That(actual.Kernel, Is.TypeOf<GaussianKernel>());
             Assert.That(((GaussianKernel)actual.Kernel).Gamma, Is.EqualTo(0.5));
-            Assert.That(actual.KernelMeans.ToArray(), Is.EqualTo(new[] { 5.0, 6.0 }));
-            Assert.That(actual.TotalMean, Is.EqualTo(7.0));
-            Assert.That(actual.Projection[0, 0], Is.EqualTo(1.0));
-            Assert.That(actual.Projection[0, 1], Is.EqualTo(0.0));
-            Assert.That(actual.Projection[1, 0], Is.EqualTo(0.0));
-            Assert.That(actual.Projection[1, 1], Is.EqualTo(1.0));
         }
 
         [Test]
-        public void RoundTripKernelPcaKeepsTransformBehavior()
+        public void RoundTripKernelPcaKeepsTransformBehaviorByRefitting()
         {
             var options = NumFlatJsonSerializerOptions.Create();
             var source = CreateKernelPca();
@@ -49,29 +43,47 @@ namespace SerializationJsonTest
         }
 
         [Test]
-        public void DeserializeKernelPcaWithInvalidShapeThrowsJsonException()
+        public void DeserializeKernelPcaIgnoresLegacyFittedParametersAndRefits()
         {
             var options = NumFlatJsonSerializerOptions.Create();
-            const string json = @"{""sourceVectors"":[[1,3],[2,4]],""kernel"":{""type"":""linear""},""kernelMeans"":[5],""totalMean"":7,""projection"":[[1,0],[0,1]]}";
+            const string json = @"{""sourceVectors"":[[1,3],[2,4]],""kernel"":{""type"":""gaussian"",""gamma"":0.5},""kernelMeans"":[5,6],""totalMean"":7,""projection"":[[1,0],[0,1]]}";
+
+            var actual = JsonSerializer.Deserialize<KernelPrincipalComponentAnalysis>(json, options)!;
+            var expected = CreateKernelPca();
+            var x = new Vec<double>(new[] { 5.0, 6.0 });
+
+            Assert.That(actual.Transform(x).ToArray(), Is.EqualTo(expected.Transform(x).ToArray()).Within(1.0e-12));
+            Assert.That(actual.KernelMeans.ToArray(), Is.Not.EqualTo(new[] { 5.0, 6.0 }));
+            Assert.That(actual.TotalMean, Is.Not.EqualTo(7.0));
+        }
+
+        [Test]
+        public void DeserializeKernelPcaWithoutKernelThrowsJsonException()
+        {
+            var options = NumFlatJsonSerializerOptions.Create();
+            const string json = @"{""sourceVectors"":[[1,3],[2,4]]}";
+
+            Assert.That((Action)(() => JsonSerializer.Deserialize<KernelPrincipalComponentAnalysis>(json, options)), Throws.TypeOf<JsonException>());
+        }
+
+        [Test]
+        public void DeserializeKernelPcaWithEmptySourceVectorsThrowsJsonException()
+        {
+            var options = NumFlatJsonSerializerOptions.Create();
+            const string json = @"{""sourceVectors"":[],""kernel"":{""type"":""linear""}}";
 
             Assert.That((Action)(() => JsonSerializer.Deserialize<KernelPrincipalComponentAnalysis>(json, options)), Throws.TypeOf<JsonException>());
         }
 
         private static KernelPrincipalComponentAnalysis CreateKernelPca()
         {
-            var sourceVectors = new Mat<double>(2, 2, 2, new[]
+            var xs = new[]
             {
-                1.0, 2.0,
-                3.0, 4.0
-            });
-            var kernelMeans = new Vec<double>(new[] { 5.0, 6.0 });
-            var projection = new Mat<double>(2, 2, 2, new[]
-            {
-                1.0, 0.0,
-                0.0, 1.0
-            });
+                new Vec<double>(new[] { 1.0, 2.0 }),
+                new Vec<double>(new[] { 3.0, 4.0 })
+            };
 
-            return new KernelPrincipalComponentAnalysis(sourceVectors, Kernel.Gaussian(0.5), kernelMeans, 7.0, projection);
+            return new KernelPrincipalComponentAnalysis(xs, Kernel.Gaussian(0.5));
         }
     }
 }


### PR DESCRIPTION
### Motivation
- Prevent persisting internal fitted parameters and force refitting on deserialization to avoid brittle/invalid persisted state.

### Description
- Removed the deserialization-targeted constructor that accepted fitted parameters (`kernelMeans`, `totalMean`, `projection`) from `KernelPrincipalComponentAnalysis` and stopped writing those internals to JSON.
- Simplified `KernelPrincipalComponentAnalysisJsonConverter` to serialize and deserialize only `sourceVectors` and `kernel`, and to reconstruct the model by refitting via the public constructor `KernelPrincipalComponentAnalysis(sourceVectors, kernel)`.
- Updated serialization output to omit `kernelMeans`, `totalMean`, and `projection` and to ignore those legacy properties when present in input JSON.
- Adjusted tests to reflect the new behavior and added checks for legacy/invalid JSON handling.

### Testing
- Ran `SerializationJsonTest.KernelPrincipalComponentAnalysisTests` which includes `RoundTripKernelPcaStoresTrainingDataAndKernelOnly`, `RoundTripKernelPcaKeepsTransformBehaviorByRefitting`, `DeserializeKernelPcaIgnoresLegacyFittedParametersAndRefits`, `DeserializeKernelPcaWithoutKernelThrowsJsonException`, and `DeserializeKernelPcaWithEmptySourceVectorsThrowsJsonException`, and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a298e2f50d8832683a26f690f1733bf)