### PR TITLE
Avoid unnecessary ToArray allocations in Vector/Matrix JSON converters

### DIFF
--- a/SerializationJson/MatrixJsonConverter.cs
+++ b/SerializationJson/MatrixJsonConverter.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Numerics;
+using System.Runtime.InteropServices;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 
@@ -77,7 +78,7 @@ namespace NumFlat.Serialization.Json
                         throw new JsonException("A NumFlat matrix row cannot be empty.");
                     }
 
-                    return new Vec<T>(elements.ToArray());
+                    return VectorBuilder.Create<T>(CollectionsMarshal.AsSpan(elements));
                 }
 
                 elements.Add(ReadElement(ref reader));
@@ -95,7 +96,7 @@ namespace NumFlat.Serialization.Json
 
             try
             {
-                return MatrixBuilder.Create<T>(rows.ToArray());
+                return MatrixBuilder.Create<T>(CollectionsMarshal.AsSpan(rows));
             }
             catch (ArgumentException ex)
             {

--- a/SerializationJson/VectorJsonConverter.cs
+++ b/SerializationJson/VectorJsonConverter.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Numerics;
+using System.Runtime.InteropServices;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 
@@ -35,7 +36,7 @@ namespace NumFlat.Serialization.Json
                         return default;
                     }
 
-                    return new Vec<T>(elements.ToArray());
+                    return VectorBuilder.Create<T>(CollectionsMarshal.AsSpan(elements));
                 }
 
                 elements.Add(ReadElement(ref reader));


### PR DESCRIPTION
### Motivation
- Reduce extra heap allocations and array copies during JSON deserialization for `Vec<T>` and `Mat<T>` to improve performance and memory usage. 
- Use the public builder APIs (`VectorBuilder.Create` / `MatrixBuilder.Create`) which accept spans to avoid redundant temporary arrays.

### Description
- Replaced converter-side `elements.ToArray()` usage with `VectorBuilder.Create<T>(CollectionsMarshal.AsSpan(elements))` to build vectors without allocating an intermediate array in `SerializationJson/VectorJsonConverter.cs`.
- Replaced `rows.ToArray()` with `MatrixBuilder.Create<T>(CollectionsMarshal.AsSpan(rows))` and similarly used `VectorBuilder.Create` for row construction in `SerializationJson/MatrixJsonConverter.cs` to avoid an extra rows-array copy.
- Added `using System.Runtime.InteropServices;` to both converters to use `CollectionsMarshal.AsSpan`.
- Modified files: `SerializationJson/VectorJsonConverter.cs` and `SerializationJson/MatrixJsonConverter.cs`.

### Testing
- Running `dotnet test SerializationJsonTest/SerializationJsonTest.csproj` (which performs restore) executed the test suite and all unit tests passed (`Passed: 68, Failed: 0`).
- An initial `dotnet test --no-restore` failed due to missing assets before restore, but subsequent test runs passed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a29976235788326b182d31c42a94a7d)