### PR TITLE
Add DTW barycenter averaging, EuclideanSquared metric, and options validation

### DIFF
--- a/NumFlat/DistanceMetric.cs
+++ b/NumFlat/DistanceMetric.cs
@@ -38,6 +38,14 @@ namespace NumFlat
         };
 
         /// <summary>
+        /// Gets the Euclidean squared distance metric.
+        /// </summary>
+        public static DistanceMetric<Vec<double>, Vec<double>> EuclideanSquared => (Vec<double> x, Vec<double> y) =>
+        {
+            return x.DistanceSquared(y);
+        };
+
+        /// <summary>
         /// Gets the Manhattan distance metric.
         /// </summary>
         public static DistanceMetric<Vec<double>, Vec<double>> Manhattan => (Vec<double> x, Vec<double> y) =>

--- a/NumFlat/TimeSeries/DtwBarycenterAveraging.cs
+++ b/NumFlat/TimeSeries/DtwBarycenterAveraging.cs
@@ -1,27 +1,187 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace NumFlat.TimeSeries
 {
+    /// <summary>
+    /// Provides DTW barycenter averaging for vector-valued time series.
+    /// </summary>
     public static class DtwBarycenterAveraging
     {
-        public static IReadOnlyList<Vec<double>> Fit(IReadOnlyList<IReadOnlyList<Vec<double>>> sequences, DtwBarycenterAveragingOptions options)
+        /// <summary>
+        /// Computes a barycenter sequence from the source sequences using DTW barycenter averaging.
+        /// </summary>
+        /// <param name="sourceSequences">
+        /// The source sequences. Each element in every sequence must be a non-empty vector of the same dimension.
+        /// </param>
+        /// <param name="options">
+        /// Specifies options for DTW barycenter averaging.
+        /// If null, default options are used.
+        /// </param>
+        /// <returns>
+        /// The computed barycenter sequence.
+        /// </returns>
+        /// <exception cref="FittingFailureException">
+        /// Failed to fit the barycenter.
+        /// </exception>
+        public static IReadOnlyList<Vec<double>> Fit(IReadOnlyList<IReadOnlyList<Vec<double>>> sourceSequences, DtwBarycenterAveragingOptions? options = null)
         {
-            // DTW barycenter averagingを実行して、平均シーケンスを返す
-            // optionのmaxIterationsとtoleranceを使用して収束判定を行う
-            return null;
+            ThrowIfInvalidSequences(sourceSequences, nameof(sourceSequences));
+            options ??= new DtwBarycenterAveragingOptions();
+
+            try
+            {
+                var currentBarycenter = GetInitialGuess(sourceSequences).Select(vector => vector.Copy()).ToArray();
+                var previousCost = double.PositiveInfinity;
+                for (var i = 0; i < options.MaxIterations; i++)
+                {
+                    var (updatedBarycenter, averageCost) = Update(currentBarycenter, sourceSequences);
+                    if (Math.Abs(previousCost - averageCost) < options.Tolerance)
+                    {
+                        return updatedBarycenter;
+                    }
+                    if (previousCost < averageCost)
+                    {
+                        return updatedBarycenter;
+                    }
+
+                    currentBarycenter = updatedBarycenter;
+                    previousCost = averageCost;
+                }
+
+                return currentBarycenter;
+            }
+            catch (FittingFailureException)
+            {
+                throw;
+            }
+            catch (Exception e)
+            {
+                throw new FittingFailureException("Failed to fit the barycenter.", e);
+            }
         }
 
-        public static IReadOnlyList<Vec<double>> GetInitialGuess(IReadOnlyList<IReadOnlyList<Vec<double>>> sequences)
+        /// <summary>
+        /// Selects the source sequence with the smallest total DTW distance to the other source sequences.
+        /// </summary>
+        /// <param name="sourceSequences">
+        /// The source sequences.
+        /// </param>
+        /// <returns>
+        /// A copy of the selected initial barycenter sequence.
+        /// </returns>
+        public static IReadOnlyList<Vec<double>> GetInitialGuess(IReadOnlyList<IReadOnlyList<Vec<double>>> sourceSequences)
         {
-            // DTW距離が最小となるシーケンスを初期推定値として選択する
-            return null;
+            ThrowIfInvalidSequences(sourceSequences, nameof(sourceSequences));
+
+            var totalDistances = new double[sourceSequences.Count];
+            for (var i = 0; i < sourceSequences.Count; i++)
+            {
+                for (var j = i + 1; j < sourceSequences.Count; j++)
+                {
+                    var distance = DynamicTimeWarping.GetDistance(sourceSequences[i], sourceSequences[j], DistanceMetric.EuclideanSquared);
+                    totalDistances[i] += distance;
+                    totalDistances[j] += distance;
+                }
+            }
+
+            var bestIndex = -1;
+            var bestDistance = double.MaxValue;
+            for (var i = 0; i < sourceSequences.Count; i++)
+            {
+                if (totalDistances[i] < bestDistance)
+                {
+                    bestDistance = totalDistances[i];
+                    bestIndex = i;
+                }
+            }
+
+            return sourceSequences[bestIndex].Select(vector => vector.Copy()).ToArray();
         }
 
-        public static (Vec<double>[] Sequence, double Error) Update(IReadOnlyList<IReadOnlyList<Vec<double>>> sequences)
+        /// <summary>
+        /// Executes one iteration of DTW barycenter averaging to update a barycenter sequence.
+        /// </summary>
+        /// <param name="currentBarycenter">
+        /// The current barycenter sequence to update.
+        /// </param>
+        /// <param name="sourceSequences">
+        /// The source sequences.
+        /// </param>
+        /// <returns>
+        /// The updated barycenter sequence and the average DTW alignment cost computed during the update process.
+        /// </returns>
+        public static (Vec<double>[] Barycenter, double AverageCost) Update(IReadOnlyList<Vec<double>> currentBarycenter, IReadOnlyList<IReadOnlyList<Vec<double>>> sourceSequences)
         {
-            // DTW barycenter averagingのイテレーション一回分を実行
-            return (null, 0.0);
+            ThrowIfInvalidSequence(currentBarycenter, nameof(currentBarycenter));
+            var dimension = currentBarycenter[0].Count;
+            ThrowIfInvalidSequences(sourceSequences, nameof(sourceSequences), dimension);
+
+            var sums = new Vec<double>[currentBarycenter.Count];
+            var counts = new int[currentBarycenter.Count];
+            for (var i = 0; i < sums.Length; i++)
+            {
+                sums[i] = new Vec<double>(dimension);
+            }
+
+            var cost = 0.0;
+            foreach (var sourceSequence in sourceSequences)
+            {
+                var (distance, alignment) = DynamicTimeWarping.GetDistanceAndAlignment(currentBarycenter, sourceSequence, DistanceMetric.EuclideanSquared);
+                cost += distance;
+                foreach (var pair in alignment)
+                {
+                    sums[pair.First].AddInplace(sourceSequence[pair.Second]);
+                    counts[pair.First]++;
+                }
+            }
+
+            for (var i = 0; i < sums.Length; i++)
+            {
+                if (counts[i] == 0)
+                {
+                    sums[i] = currentBarycenter[i].Copy();
+                }
+                else
+                {
+                    sums[i].DivInplace(counts[i]);
+                }
+            }
+
+            return (sums, cost / sourceSequences.Count);
+        }
+
+        private static void ThrowIfInvalidSequences(IReadOnlyList<IReadOnlyList<Vec<double>>> sourceSequences, string paramName, int? dimension = null)
+        {
+            ThrowHelper.ThrowIfNull(sourceSequences, paramName);
+            if (sourceSequences.Count == 0)
+            {
+                throw new ArgumentException("The sequence must contain at least one sequence.", paramName);
+            }
+
+            foreach (var sequence in sourceSequences)
+            {
+                ThrowIfInvalidSequence(sequence, paramName, dimension);
+                dimension ??= sequence[0].Count;
+            }
+        }
+
+        private static void ThrowIfInvalidSequence(IReadOnlyList<Vec<double>> sequence, string paramName, int? dimension = null)
+        {
+            ThrowHelper.ThrowIfNull(sequence, paramName);
+            ThrowHelper.ThrowIfEmpty(sequence, paramName);
+
+            var expectedDimension = dimension;
+            foreach (var vector in sequence)
+            {
+                ThrowHelper.ThrowIfEmpty(vector, paramName);
+                expectedDimension ??= vector.Count;
+                if (vector.Count != expectedDimension.Value)
+                {
+                    throw new ArgumentException("All vectors must have the same length.", paramName);
+                }
+            }
         }
     }
 }

--- a/NumFlat/TimeSeries/DtwBarycenterAveragingOptions.cs
+++ b/NumFlat/TimeSeries/DtwBarycenterAveragingOptions.cs
@@ -1,16 +1,58 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace NumFlat.TimeSeries
 {
-    public class DtwBarycenterAveragingOptions
+    /// <summary>
+    /// Specifies options for DTW barycenter averaging.
+    /// </summary>
+    public sealed class DtwBarycenterAveragingOptions
     {
         private int maxIterations;
         private double tolerance;
 
-        // デフォルト値はtslearnの実装にあわせる
+        /// <summary>
+        /// Creates an instance of <see cref="DtwBarycenterAveragingOptions"/> with default parameters.
+        /// </summary>
+        public DtwBarycenterAveragingOptions()
+        {
+            maxIterations = 30;
+            tolerance = 1.0E-5;
+        }
+
+        /// <summary>
+        /// The maximum number of iterations to perform.
+        /// </summary>
+        public int MaxIterations
+        {
+            get => maxIterations;
+
+            set
+            {
+                if (value <= 0)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(value), "The maximum number of iterations must be greater than zero.");
+                }
+
+                maxIterations = value;
+            }
+        }
+
+        /// <summary>
+        /// Specify the amount of change to be considered converging.
+        /// </summary>
+        public double Tolerance
+        {
+            get => tolerance;
+
+            set
+            {
+                if (value <= 0)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(value), "The tolerance value must be greater than zero.");
+                }
+
+                tolerance = value;
+            }
+        }
     }
 }


### PR DESCRIPTION
### Motivation

- Provide a complete implementation of DTW barycenter averaging for vector-valued time series to compute barycenter sequences.
- Improve distance metric support by adding a squared-Euclidean metric for DTW computations and align with performance/algorithmic needs.
- Surface configurable convergence control with validated options for iteration count and tolerance.

### Description

- Added `DistanceMetric.EuclideanSquared` that returns `x.DistanceSquared(y)` for use by DTW routines.
- Implemented `DtwBarycenterAveraging` with `Fit`, `GetInitialGuess`, and `Update` methods, including copy-on-initialization, iterative update loop, convergence checks using `DtwBarycenterAveragingOptions`, and exception wrapping into `FittingFailureException` when unexpected errors occur.
- Implemented input validation helpers `ThrowIfInvalidSequences` and `ThrowIfInvalidSequence` to ensure non-null, non-empty sequences and consistent vector dimensions; added `using System.Linq` for sequence operations.
- Implemented `DtwBarycenterAveragingOptions` with default values, properties `MaxIterations` and `Tolerance`, and argument validation that throws `ArgumentOutOfRangeException` for invalid settings.

### Testing

- No automated tests were included or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a49c50d53e08326a9396bafe18060b8)